### PR TITLE
fix:updating opensearch policy to check the version for encryption

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/elasticsearch/ESEncryptionAtRestRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/elasticsearch/ESEncryptionAtRestRule.java
@@ -25,6 +25,7 @@ public class ESEncryptionAtRestRule extends BaseRule {
 
 
 	public static final String ES_PROP_ENCRYPTION_ENABLED = "encryptionenabled";
+	public static final String ES_PROP_VERSION = "elasticsearchversion";
 
 
 	/**
@@ -80,12 +81,14 @@ public class ESEncryptionAtRestRule extends BaseRule {
 		if (resourceAttributes != null) {
 			String esEncryEnable = StringUtils.trim(resourceAttributes.get(ES_PROP_ENCRYPTION_ENABLED));
 
-				if (esEncryEnable == null || "".equals(esEncryEnable) 
-						|| !PacmanRuleConstants.TRUE_VAL.equalsIgnoreCase(esEncryEnable) ) {
+				if (Double.parseDouble(resourceAttributes.get(ES_PROP_VERSION)) >= 5.1 &&
+						(esEncryEnable == null || "".equals(esEncryEnable) 
+						|| !PacmanRuleConstants.TRUE_VAL.equalsIgnoreCase(esEncryEnable) )) {
 					List<LinkedHashMap<String, Object>> issueList = new ArrayList<>();
 					LinkedHashMap<String, Object> issue = new LinkedHashMap<>();
 					annotation = Annotation.buildAnnotation(ruleParam, Annotation.Type.ISSUE);
-					annotation.put(PacmanSdkConstants.DESCRIPTION, "ES domain are not encrypted!!");
+					annotation.put(PacmanSdkConstants.DESCRIPTION, "ES domain are not encrypted."
+							+ "At rest encryption should be enabled for OpenSearch with version 5.1 or greater!!");
 					annotation.put(PacmanRuleConstants.SEVERITY, severity);;
 					annotation.put(PacmanRuleConstants.CATEGORY, category);
 					issue.put(PacmanRuleConstants.VIOLATION_REASON,

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/elasticsearch/ESEncryptionUsingKMSCMKsRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/elasticsearch/ESEncryptionUsingKMSCMKsRule.java
@@ -26,6 +26,7 @@ public class ESEncryptionUsingKMSCMKsRule extends BaseRule {
 	public static final String ES_PROP_ENCRYPTION_ENABLED = "encryptionenabled";
 	public static final String ES_PROP_KMS_KEY = "encryptionkmskey";
 	public static final String ES_PROP_KMS_DEFAULT_VALUE = "(Default) aws/es";
+	public static final String ES_PROP_VERSION = "elasticsearchversion";
 
 	/**
 	 * The method will get triggered from Rule Engine with following parameters
@@ -78,13 +79,15 @@ public class ESEncryptionUsingKMSCMKsRule extends BaseRule {
 		if (resourceAttributes != null) {
 			String esEncryEnable = StringUtils.trim(resourceAttributes.get(ES_PROP_ENCRYPTION_ENABLED));
 			String eskmsKey = StringUtils.trim(resourceAttributes.get(ES_PROP_KMS_KEY));
-			String issueDescription = "ES domain are not encrypted!!";
+			String issueDescription = "ES domain are not encrypted. OpenSearch domain should be encrypted with CMKs for version 5.1 or greater !!";
 
-			if (esEncryEnable == null || "".equals(esEncryEnable) || eskmsKey == null || "".equals(eskmsKey)
-					|| ES_PROP_KMS_DEFAULT_VALUE.equalsIgnoreCase(eskmsKey)) {
+			if (Double.parseDouble(resourceAttributes.get(ES_PROP_VERSION)) >= 5.1 &&
+					(esEncryEnable == null || "".equals(esEncryEnable) || eskmsKey == null || "".equals(eskmsKey)
+					|| ES_PROP_KMS_DEFAULT_VALUE.equalsIgnoreCase(eskmsKey))) {
 				if (PacmanRuleConstants.TRUE_VAL.equalsIgnoreCase(esEncryEnable)
 						&& ES_PROP_KMS_DEFAULT_VALUE.equalsIgnoreCase(eskmsKey)) {
-					issueDescription = " ES domain is encrypted with default AWS KMS key";
+					issueDescription = " ES domain is encrypted with default AWS KMS key. "
+							+ "OpenSearch domain should be encrypted with CMKs for version 5.1 or greater !!";
 				}
 				List<LinkedHashMap<String, Object>> issueList = new ArrayList<>();
 				LinkedHashMap<String, Object> issue = new LinkedHashMap<>();

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/elasticsearch/ESNodetoNodeEncryptionRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/elasticsearch/ESNodetoNodeEncryptionRule.java
@@ -25,7 +25,7 @@ public class ESNodetoNodeEncryptionRule extends BaseRule {
 
 
 	public static final String ES_PROP_NODE_ENCRYPTION = "nodetonodeencryption";
-
+	public static final String ES_PROP_VERSION = "elasticsearchversion";
 
 	/**
 	 * The method will get triggered from Rule Engine with following parameters
@@ -80,12 +80,14 @@ public class ESNodetoNodeEncryptionRule extends BaseRule {
 		if (resourceAttributes != null) {
 			String nodeEncy = StringUtils.trim(resourceAttributes.get(ES_PROP_NODE_ENCRYPTION));
 
-				if (nodeEncy == null || "".equals(nodeEncy) 
-						|| !PacmanRuleConstants.TRUE_VAL.equalsIgnoreCase(nodeEncy) ) {
+				if (Double.parseDouble(resourceAttributes.get(ES_PROP_VERSION)) >= 6.0 &&
+						(nodeEncy == null || "".equals(nodeEncy) 
+						|| !PacmanRuleConstants.TRUE_VAL.equalsIgnoreCase(nodeEncy)) ) {
 					List<LinkedHashMap<String, Object>> issueList = new ArrayList<>();
 					LinkedHashMap<String, Object> issue = new LinkedHashMap<>();
 					annotation = Annotation.buildAnnotation(ruleParam, Annotation.Type.ISSUE);
-					annotation.put(PacmanSdkConstants.DESCRIPTION, "ES node to node encryption not enabled!!");
+					annotation.put(PacmanSdkConstants.DESCRIPTION, "ES node to node encryption not enabled."
+							+ "Node to node encryption should be enabled for OpenSearch with version 6.0 or greater!! ");
 					annotation.put(PacmanRuleConstants.SEVERITY, severity);;
 					annotation.put(PacmanRuleConstants.CATEGORY, category);
 					issue.put(PacmanRuleConstants.VIOLATION_REASON,

--- a/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/elasticsearch/ESEncryptionAtRestRuleTest.java
+++ b/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/elasticsearch/ESEncryptionAtRestRuleTest.java
@@ -52,6 +52,18 @@ public class ESEncryptionAtRestRuleTest {
 		RuleResult ruleResult = esEncryptionAtRestRule.execute(ruleParam, resourceAttribute);
 		assertEquals(PacmanSdkConstants.STATUS_FAILURE, ruleResult.getStatus());
 	}
+	@Test
+	public void esWithLowerVersion() {
+		Map<String, String> ruleParam = new HashMap<>();
+		ruleParam.put(PacmanSdkConstants.EXECUTION_ID, "exectionid");
+		ruleParam.put(PacmanSdkConstants.RULE_ID, "esEncryptionAtRestRule");
+		ruleParam.put(PacmanRuleConstants.CATEGORY, PacmanSdkConstants.SECURITY);
+		ruleParam.put(PacmanRuleConstants.SEVERITY, PacmanSdkConstants.SEV_HIGH);
+
+		Map<String, String> resourceAttribute = getResourceForWithLowerVersion("ES1234");
+		RuleResult ruleResult = esEncryptionAtRestRule.execute(ruleParam, resourceAttribute);
+		assertEquals(PacmanSdkConstants.STATUS_FAILURE, ruleResult.getStatus());
+	}
 
 	@Test
 	public void getHelpTextTest() {
@@ -64,6 +76,7 @@ public class ESEncryptionAtRestRuleTest {
 		clusterObj.put("name", "AWS-ES");
 		clusterObj.put("creationTimestamp", "2022-01-10T13:00:38.628-08:00");
 		clusterObj.put("encryptionenabled", "true");
+		clusterObj.put("elasticsearchversion", "5.5");
 
 		return clusterObj;
 	}
@@ -74,6 +87,17 @@ public class ESEncryptionAtRestRuleTest {
 		clusterObj.put("name", "AWS-ES");
 		clusterObj.put("creationTimestamp", "2022-01-10T13:00:38.628-08:00");
 		clusterObj.put("encryptionenabled", "false");
+		clusterObj.put("elasticsearchversion", "5.5");
+
+		return clusterObj;
+	}
+	private Map<String, String> getResourceForWithLowerVersion(String clusterID) {
+		Map<String, String> clusterObj = new HashMap<>();
+		clusterObj.put("_resourceid", clusterID);
+		clusterObj.put("name", "AWS-ES");
+		clusterObj.put("creationTimestamp", "2022-01-10T13:00:38.628-08:00");
+		clusterObj.put("encryptionenabled", "false");
+		clusterObj.put("elasticsearchversion", "5.0");
 
 		return clusterObj;
 	}

--- a/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/elasticsearch/ESEncryptionUsingKMSCMKsRuleTest.java
+++ b/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/elasticsearch/ESEncryptionUsingKMSCMKsRuleTest.java
@@ -64,6 +64,19 @@ public class ESEncryptionUsingKMSCMKsRuleTest {
 		RuleResult ruleResult = esEncryptionUsingKMSCMKsRule.execute(ruleParam, resourceAttribute);
 		assertEquals(PacmanSdkConstants.STATUS_FAILURE, ruleResult.getStatus());
 	}
+	
+	@Test
+	public void esWithLowerVersion() {
+		Map<String, String> ruleParam = new HashMap<>();
+		ruleParam.put(PacmanSdkConstants.EXECUTION_ID, "exectionid");
+		ruleParam.put(PacmanSdkConstants.RULE_ID, "esEncryptionAtRestRule");
+		ruleParam.put(PacmanRuleConstants.CATEGORY, PacmanSdkConstants.SECURITY);
+		ruleParam.put(PacmanRuleConstants.SEVERITY, PacmanSdkConstants.SEV_HIGH);
+
+		Map<String, String> resourceAttribute = getResourceWithLowerVersion("ES1234");
+		RuleResult ruleResult = esEncryptionUsingKMSCMKsRule.execute(ruleParam, resourceAttribute);
+		assertEquals(PacmanSdkConstants.STATUS_FAILURE, ruleResult.getStatus());
+	}
 
 	@Test
 	public void getHelpTextTest() {
@@ -77,6 +90,7 @@ public class ESEncryptionUsingKMSCMKsRuleTest {
 		clusterObj.put("creationTimestamp", "2022-01-10T13:00:38.628-08:00");
 		clusterObj.put("encryptionenabled", "true");
 		clusterObj.put("encryptionkmskey", "(Default) aws/es");
+		clusterObj.put("elasticsearchversion", "5.5");
 
 		return clusterObj;
 	}
@@ -88,6 +102,7 @@ public class ESEncryptionUsingKMSCMKsRuleTest {
 		clusterObj.put("creationTimestamp", "2022-01-10T13:00:38.628-08:00");
 		clusterObj.put("encryptionenabled", "true");
 		clusterObj.put("encryptionkmskey", "true");
+		clusterObj.put("elasticsearchversion", "5.5");
 
 		return clusterObj;
 	}
@@ -98,6 +113,19 @@ public class ESEncryptionUsingKMSCMKsRuleTest {
 		clusterObj.put("name", "AWS-ES");
 		clusterObj.put("creationTimestamp", "2022-01-10T13:00:38.628-08:00");
 		clusterObj.put("encryptionenabled", "false");
+		clusterObj.put("elasticsearchversion", "5.5");
+
+		return clusterObj;
+	}
+	
+	private Map<String, String> getResourceWithLowerVersion(String clusterID) {
+		Map<String, String> clusterObj = new HashMap<>();
+		clusterObj.put("_resourceid", clusterID);
+		clusterObj.put("name", "AWS-ES");
+		clusterObj.put("creationTimestamp", "2022-01-10T13:00:38.628-08:00");
+		clusterObj.put("encryptionenabled", "true");
+		clusterObj.put("encryptionkmskey", "(Default) aws/es");
+		clusterObj.put("elasticsearchversion", "5.0");
 
 		return clusterObj;
 	}

--- a/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/elasticsearch/ESNodetoNodeEncryptionRuleTest.java
+++ b/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/elasticsearch/ESNodetoNodeEncryptionRuleTest.java
@@ -52,6 +52,19 @@ public class ESNodetoNodeEncryptionRuleTest {
 		RuleResult ruleResult = esNodetoNodeEncryptionRule.execute(ruleParam, resourceAttribute);
 		assertEquals(PacmanSdkConstants.STATUS_FAILURE, ruleResult.getStatus());
 	}
+	
+	@Test
+	public void esNodeWithLowerVersion() {
+		Map<String, String> ruleParam = new HashMap<>();
+		ruleParam.put(PacmanSdkConstants.EXECUTION_ID, "exectionid");
+		ruleParam.put(PacmanSdkConstants.RULE_ID, "esEncryptionAtRestRule");
+		ruleParam.put(PacmanRuleConstants.CATEGORY, PacmanSdkConstants.SECURITY);
+		ruleParam.put(PacmanRuleConstants.SEVERITY, PacmanSdkConstants.SEV_HIGH);
+
+		Map<String, String> resourceAttribute = getResourceWithLowerVersion("ES1234");
+		RuleResult ruleResult = esNodetoNodeEncryptionRule.execute(ruleParam, resourceAttribute);
+		assertEquals(PacmanSdkConstants.STATUS_FAILURE, ruleResult.getStatus());
+	}
 
 	@Test
 	public void getHelpTextTest() {
@@ -64,6 +77,7 @@ public class ESNodetoNodeEncryptionRuleTest {
 		clusterObj.put("name", "AWS-ES");
 		clusterObj.put("creationTimestamp", "2022-01-10T13:00:38.628-08:00");
 		clusterObj.put("nodetonodeencryption", "true");
+		clusterObj.put("elasticsearchversion", "6.0");
 
 		return clusterObj;
 	}
@@ -74,6 +88,18 @@ public class ESNodetoNodeEncryptionRuleTest {
 		clusterObj.put("name", "AWS-ES");
 		clusterObj.put("creationTimestamp", "2022-01-10T13:00:38.628-08:00");
 		clusterObj.put("nodetonodeencryption", "false");
+		clusterObj.put("elasticsearchversion", "6.0");
+
+		return clusterObj;
+	}
+	
+	private Map<String, String> getResourceWithLowerVersion(String clusterID) {
+		Map<String, String> clusterObj = new HashMap<>();
+		clusterObj.put("_resourceid", clusterID);
+		clusterObj.put("name", "AWS-ES");
+		clusterObj.put("creationTimestamp", "2022-01-10T13:00:38.628-08:00");
+		clusterObj.put("nodetonodeencryption", "false");
+		clusterObj.put("elasticsearchversion", "5.5");
 
 		return clusterObj;
 	}


### PR DESCRIPTION
# Description

Updating opensearch encryption policies to check the version. To enable node to node encryption , the version should be greater than 6.0 and for at rest encryption, it should be greater than 5.1.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The commit message/PR follows our guidelines

# **Other information**:
