### PR TITLE
chore: updated lambda run time to 3.9

### DIFF
--- a/installer/resources/lambda_rule_engine/function.py
+++ b/installer/resources/lambda_rule_engine/function.py
@@ -19,7 +19,7 @@ class RuleEngineLambdaFunction(LambdaFunctionResource):
     function_name = "ruleengine"
     role = LambdaRole.get_output_attr('arn')
     handler = RULE_ENGINE_JOB_FILE_NAME + ".lambda_handler"
-    runtime = "python3.6"
+    runtime = "python3.9"
     s3_bucket = BucketStorage.get_output_attr('bucket')
     s3_key = UploadLambdaRuleEngineZipFile.get_output_attr('id')
     environment = {

--- a/installer/resources/lambda_submit/function.py
+++ b/installer/resources/lambda_submit/function.py
@@ -38,7 +38,7 @@ class SubmitJobLambdaFunction(LambdaFunctionResource):
     function_name = "datacollector"
     role = LambdaRole.get_output_attr('arn')
     handler = BATCH_JOB_FILE_NAME + ".lambda_handler"
-    runtime = "python3.6"
+    runtime = "python3.9"
     s3_bucket = BucketStorage.get_output_attr('bucket')
     s3_key = UploadLambdaSubmitJobZipFile.get_output_attr('id') 
     environment = {


### PR DESCRIPTION
# Description

Updated the lambda runtime version from 3.6 to 3.9.
AWS deprecated the 3.6.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] The commit message/PR follows our guidelines

