### PR TITLE
fix: fixed asset details table data load when resourceId in violation…

### DIFF
--- a/webapp/src/app/pacman-features/modules/assets/asset-details/asset-details.component.html
+++ b/webapp/src/app/pacman-features/modules/assets/asset-details/asset-details.component.html
@@ -28,7 +28,7 @@
                 <ul class='adjust-padding'>
                     <li class="widget-wrapper">
                         <div class="widget">
-                            <app-pacman-policy-violations [resourceId]='resourceId' [resourceType]='resourceType'
+                            <app-pacman-policy-violations *ngIf="resourceId" [resourceId]='resourceId' [resourceType]='resourceType'
                                 [pageLevel]="pageLevel"></app-pacman-policy-violations>
                         </div>
                     </li>

--- a/webapp/src/app/pacman-features/secondary-components/installed-softwares/installed-softwares.component.ts
+++ b/webapp/src/app/pacman-features/secondary-components/installed-softwares/installed-softwares.component.ts
@@ -336,7 +336,9 @@ export class InstalledSoftwaresComponent implements OnInit, OnDestroy {
   }
   ngOnDestroy() {
     try {
-      this.dataSubscription.unsubscribe();
+      if (this.dataSubscription) {
+        this.dataSubscription.unsubscribe();
+      }
     } catch (error) {
         this.errorMessage = this.errorHandling.handleJavascriptError(error);
         this.getErrorValues();

--- a/webapp/src/app/pacman-features/secondary-components/open-ports/open-ports.component.ts
+++ b/webapp/src/app/pacman-features/secondary-components/open-ports/open-ports.component.ts
@@ -305,7 +305,9 @@ export class OpenPortsComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     try {
       this.subscriptionToAssetGroup.unsubscribe();
-      this.dataSubscription.unsubscribe();
+      if (this.dataSubscription) {
+        this.dataSubscription.unsubscribe();
+      }
     } catch (error) {
       this.errorMessage = this.errorHandling.handleJavascriptError(error);
       this.getErrorValues();


### PR DESCRIPTION
Fixed asset details table data load when resourceId in violation details is clicked

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The commit message/PR follows our guidelines
