### PR TITLE
fix: Corrected asset count trend API to return all-time data by default

### DIFF
--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/controller/AssetTrendController.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/controller/AssetTrendController.java
@@ -99,13 +99,6 @@ public class AssetTrendController {
         try {
             Date from = fromDate;
             Date to = toDate;
-            if (from == null && to == null) {
-                Calendar cal = Calendar.getInstance();
-                cal.setTimeZone(TimeZone.getTimeZone("UTC"));
-                to = cal.getTime();
-                cal.add(Calendar.DATE, Constants.NEG_THIRTY);
-                from = cal.getTime();
-            }
             Map<String, Object> response = new LinkedHashMap<>();
             response.put("ag", assetGroup);
             List<Map<String, Object>> trendList = assetService.getAssetCountTrend(assetGroup, type, from, to);

--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/repository/AssetRepositoryImpl.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/repository/AssetRepositoryImpl.java
@@ -2760,6 +2760,7 @@ public class AssetRepositoryImpl implements AssetRepository {
                 if (sourceJson != null) {
                     Map<String, Object> doc = new Gson().fromJson(sourceJson, new TypeToken<Map<String, Object>>() {
                     }.getType());
+                    doc.remove("assetCount");
                     docs.add(doc);
                 }
             }

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/AssetGroupStatsCollector.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/AssetGroupStatsCollector.java
@@ -476,12 +476,10 @@ public class AssetGroupStatsCollector implements Constants{
                 log.info("Response from asset count API: {}", assetCountResponse);
                 long totalCount = Long.valueOf(assetCountResponse.get("totalassets").toString());
                 long typeCount = Long.valueOf(assetCountResponse.get("assettype").toString());
-                List<Map<String,Object>> assetCount=getCountByType((List<Map<String, Object>>) assetCountResponse.get("assetcount"));
                     Map<String, Object> doc = new HashMap<>();
                     doc.put("ag", ag);
                     doc.put("typeCount", typeCount);
                     doc.put("totalassets", totalCount);
-                    doc.put("assetCount", assetCount);
                     doc.put("date", CURR_DATE);
                     doc.put("@id", Util.getUniqueID(ag + CURR_DATE));
                     docs.add(doc);


### PR DESCRIPTION
# Description

- Changed the default behaviour of asset count trend API
- Removed the unwanted asset type distribution

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Tested locally the API response

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
- [x] The commit message/PR follows our guidelines

# **Other information**:
