### PR TITLE
Added RESOURCE_NAME_PREFIX

### DIFF
--- a/installer/settings/default.local.py
+++ b/installer/settings/default.local.py
@@ -7,13 +7,15 @@ VPC = {
 }
 
 
-# CUstom tags that can be defined by user
+# Custom tags that can be defined by user
 CUSTOM_RESOURCE_TAGS = {
     'Application': "PaladinCloud",
     'Environment': "Prod",
     'Created By': "customer-name"
 }
 
+#set the prefix for resources, needs changed if you run more than one instance of Paladin Coud
+RESOURCE_NAME_PREFIX = "paladincloud"
 
 # RDS Related Configurations
 # Possibble values db.m5.large, db.t3.large etc
@@ -30,7 +32,7 @@ ES_DEDICATED_MASTER_ENABLED = False
 ES_MASTER_NODE_COUNT = 1
 
 # ALB related configurations
-# False if ALB need to be public(internet facing) else True
+# False if ALB needs to be public (internet facing) else True
 MAKE_ALB_INTERNAL = True
 ALB_PROTOCOL = "HTTP"
 SSL_CERTIFICATE_ARN = ""  # Required only if ALB_PROTOCOL is defined as HTTPS
@@ -50,7 +52,7 @@ MAIL_SMTP_SSL_TEST_CONNECTION = "false"
 USER_EMAIL_ID = ""
 
 # System reads below data from user if not updated here
-# Value should be numeric 1 or 2 or 3. I. If kept like this input is read from
+# Value should be numeric 1 or 2 or 3 
 AWS_AUTH_MECHANISM = None
 # if AWS_AUTH_MECHANISM == 1
 AWS_ACCESS_KEY = ""
@@ -59,12 +61,12 @@ AWS_REGION = ""
 # If AWS_AUTH_MECHANISM == 2, AWS_ASSUME_ROLE_ARN is required
 AWS_ASSUME_ROLE_ARN = ""
 
-# This settings enable Vulnerability feature and servie
+# These settings enable the Vulnerability feature and service
 ENABLE_VULNERABILITY_FEATURE = False
 QUALYS_API_URL = ""  # Qualys API Url without trailing slash
 QUALYS_INFO = ""  # Base64 encoded user:password of qualys
 
-# Settings for enable AZURE  
+# Settings for enabling AZURE  
 ENABLE_AZURE = False
 # Tenants should be a list of dict containing tenantId, clientId and secretValue
 AZURE_TENANTS = [
@@ -79,13 +81,13 @@ AZURE_TENANTS = [
         'secretValue': "s222"
     },
 ]
-# Settings for enable GCP 
+# Settings for enabling GCP 
 ENABLE_GCP = False
 GCP_PROJECT_IDS = []
 GCP_CREDENTIALS = {}
 
 # Azure AD integration 
-AUTHENTICATION_TYPE = "DB"	# login type value any one of this "AZURE_AD or DB "
+AUTHENTICATION_TYPE = "DB"	# login type value should be any one of these "AZURE_AD or DB "
 AD_TENANT_ID = "xxxx- xxxxx_xxxx" # AD Tenant ID 
 AD_CLIENT_ID = "xxx-xxx-xxxx"  # AD Client ID
 AD_SECRET_KEY = "xxxxyyyyzzz"  # AD secret key


### PR DESCRIPTION
Added RESOURCE_NAME_PREFIX to the default local options and cleaned up some comment language in the file.

# Description

RESOURCE_NAME_PREFIX should be added to default.local.py so users can change it there instead of directly in common.py which could create conflicts with future versions.

Docs: Updates the language for some of the comments in default.local.py since those are the ones most likely to be read by developers

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update
If this is added our troubleshooting documentation should point users to modify local.py instead of common.py

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] added RESOURCE_NAME_PREFIX to my local.py file instead of modifying common.py and was able to deploy Paladin Cloud with a new prefix.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The commit message/PR follows our guidelines

# **Other information**:
