### PR TITLE
fix: Incorrect gcp application count

### DIFF
--- a/jobs/gcp-discovery/src/main/java/com/tmobile/pacbot/gcp/inventory/collector/VMInventoryCollector.java
+++ b/jobs/gcp-discovery/src/main/java/com/tmobile/pacbot/gcp/inventory/collector/VMInventoryCollector.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 public class VMInventoryCollector {
@@ -57,7 +58,7 @@ public class VMInventoryCollector {
                         VirtualMachineVH virtualMachineVH = new VirtualMachineVH();
                         virtualMachineVH.setId(String.valueOf(instance.getId()));
                         virtualMachineVH.setMachineType(instance.getMachineType());
-                        virtualMachineVH.setTags(instance.getLabelsMap());
+                        virtualMachineVH.setTags(updateApplicationTag(instance.getLabelsMap()));
                         virtualMachineVH.setProjectName(project.getProjectName());
                         virtualMachineVH.setProjectId(project.getProjectId());
                         virtualMachineVH.setName(instance.getName());
@@ -174,5 +175,18 @@ public class VMInventoryCollector {
             diskVHS.add(diskVH);
         });
         vm.setDisks(diskVHS);
+    }
+    private Map<String, String> updateApplicationTag(Map<String, String> labelsMap){
+        if(labelsMap==null || labelsMap.isEmpty()){
+            return labelsMap;
+        }
+        return labelsMap.keySet().stream()
+                .collect(Collectors.toMap(key -> {
+                    if(key.equals("application")){
+                        return "Application";
+                    }else{
+                        return key;
+                    }
+                },  labelsMap::get));
     }
 }


### PR DESCRIPTION
# Description

- Corrected the incorrect count for GCP application tag


Fixes # (issue)- Incorrect application count in the recently viewed asset group screen

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Verified vminventory collector files, the file contains the tag as 'Application' instead of 'application'. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The commit message/PR follows our guidelines

# **Other information**:
