### PR TITLE
fix: Updated no of shards in ES to 1

### DIFF
--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupExceptionServiceImpl.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupExceptionServiceImpl.java
@@ -321,7 +321,8 @@ public class AssetGroupExceptionServiceImpl implements AssetGroupExceptionServic
 	
 	private void createIndex(String indexName) {
 		if (!indexExists(indexName)) {
-			invokeAPI("PUT", indexName, null);
+			String payLoad = "{\"settings\": {  \"number_of_shards\" : 1,\"number_of_replicas\" : 1 }}";
+			invokeAPI("PUT", indexName, payLoad);
 		}
 	}
 	

--- a/api/pacman-api-vulnerability/src/main/java/com/tmobile/pacman/api/vulnerability/repository/VulnerabilityRepository.java
+++ b/api/pacman-api-vulnerability/src/main/java/com/tmobile/pacman/api/vulnerability/repository/VulnerabilityRepository.java
@@ -1296,7 +1296,7 @@ public class VulnerabilityRepository implements Constants {
 	 */
 	public void createIndex(String indexName) {
 		if (!indexExists(indexName)) {
-			String payLoad = "{\"settings\": { \"index.mapping.ignore_malformed\": true }}";
+			String payLoad = "{\"settings\": {  \"number_of_shards\" : 1,\"number_of_replicas\" : 1,\"index.mapping.ignore_malformed\": true }}";
 			invokeAPI("PUT", indexName, payLoad);
 		}
 	}

--- a/commons/pac-batch-commons/src/main/java/com/tmobile/pacman/commons/utils/ESUtils.java
+++ b/commons/pac-batch-commons/src/main/java/com/tmobile/pacman/commons/utils/ESUtils.java
@@ -172,7 +172,8 @@ public class ESUtils {
 	 */
 	public static void createIndex(String url, String indexName) throws Exception {
 		String esUrl = new StringBuilder(url).append("/").append(indexName).toString();
-		CommonUtils.doHttpPut(esUrl, null);
+		String payLoad = "{\"settings\": {  \"number_of_shards\" : 1,\"number_of_replicas\" : 1 }}";
+		CommonUtils.doHttpPut(esUrl, payLoad);
 	}
 
 	/**

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/es/ESManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/es/ESManager.java
@@ -393,7 +393,7 @@ public class ESManager implements Constants {
      */
     public static void configureIndexAndTypes(String ds, List<Map<String, String>> errorList) {
 
-        String _payLoad = "{\"settings\" : { \"number_of_shards\" : 3,\"number_of_replicas\" : 1 },\"mappings\": {";
+        String _payLoad = "{\"settings\" : { \"number_of_shards\" : 1,\"number_of_replicas\" : 1 },\"mappings\": {";
 
         Set<String> types = ConfigManager.getTypes(ds);
         Iterator<String> it = types.iterator();
@@ -562,7 +562,7 @@ public class ESManager implements Constants {
      */
     public static void createIndex(String indexName, List<Map<String, String>> errorList) {
         if (!indexExists(indexName)) {
-            String payLoad = "{\"settings\": { \"index.mapping.ignore_malformed\": true }}";
+            String payLoad = "{\"settings\": {  \"number_of_shards\" : 1,\"number_of_replicas\" : 1,\"index.mapping.ignore_malformed\": true }}";
             try {
                 invokeAPI("PUT", indexName, payLoad);
             } catch (IOException e) {

--- a/jobs/pacman-qualys-enricher/src/main/java/com/tmobile/cso/pacman/qualys/util/ElasticSearchManager.java
+++ b/jobs/pacman-qualys-enricher/src/main/java/com/tmobile/cso/pacman/qualys/util/ElasticSearchManager.java
@@ -69,7 +69,7 @@ public class ElasticSearchManager {
     public static void createIndex(String index) {
     	String indexName = "/"+index;
         if (!indexExists(indexName)) {
-            String payLoad = "{\"settings\": { \"index.mapping.ignore_malformed\": true }}";
+            String payLoad = "{\"settings\": { \"number_of_shards\" : 1,\"number_of_replicas\" : 1,\"index.mapping.ignore_malformed\": true }}";
             try {
                 invokeAPI("PUT", indexName, payLoad);
             } catch (IOException e) {

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/ESUtils.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/ESUtils.java
@@ -247,7 +247,8 @@ public class ESUtils {
      */
     public static void createIndex(String url, String indexName) throws Exception {
         String esUrl = new StringBuilder(url).append("/").append(indexName).toString();
-        CommonUtils.doHttpPut(esUrl, null);
+        String payLoad = "{\"settings\": { \"number_of_shards\" : 1,\"number_of_replicas\" : 1 }}";
+        CommonUtils.doHttpPut(esUrl, payLoad);
     }
 
     /**

--- a/jobs/recommendation-enricher/src/main/java/com/tmobile/cso/pacbot/recommendation/es/ESManager.java
+++ b/jobs/recommendation-enricher/src/main/java/com/tmobile/cso/pacbot/recommendation/es/ESManager.java
@@ -516,7 +516,7 @@ public class ESManager implements Constants {
      */
     public static void createIndex(String indexName, List<Map<String, String>> errorList) {
         if (!indexExists(indexName)) {
-            String payLoad = "{\"settings\": { \"index.mapping.ignore_malformed\": true }}";
+            String payLoad = "{\"settings\": { \"number_of_shards\" : 1,\"number_of_replicas\" : 1,\"index.mapping.ignore_malformed\": true }}";
             try {
                 invokeAPI("PUT", indexName, payLoad);
             } catch (IOException e) {


### PR DESCRIPTION
# Description

3 shards in ES are causing a lot of unnecessary reads on the cluster. Reduced the no of shards to 1. We will need to roll over once each index reaches a certain size. That will be handled later.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] The commit message/PR follows our guidelines

# **Other information**:
