### PR TITLE
Fix: Removed duplicate params for category and severity

### DIFF
--- a/webapp/src/app/pacman-features/modules/admin/create-edit-policy/create-edit-policy.component.html
+++ b/webapp/src/app/pacman-features/modules/admin/create-edit-policy/create-edit-policy.component.html
@@ -14,7 +14,6 @@
     </div> -->
         <div class="stepper">
                     <div class="right-wrapper">
-                        <form class="form-wrapper" (ngSubmit)="onSubmit(policyForm)" #policyForm="ngForm">
                             <div class="details-wrapper">
                                 <div class="details-header">
                                     <div class="details-header-text">
@@ -85,11 +84,10 @@
                                 <div class="details-footer">
                                     <div class="button-wrapper">
                                         <button class="button submit-btn" 
-                                            (click)="onSubmit(policyForm)">Update</button>
+                                            (click)="onSubmit()">Update</button>
                                     </div>
                                 </div>
                             </div>
-                        </form>
                     </div>
     </div>
 </div>

--- a/webapp/src/app/pacman-features/modules/admin/create-edit-policy/create-edit-policy.component.ts
+++ b/webapp/src/app/pacman-features/modules/admin/create-edit-policy/create-edit-policy.component.ts
@@ -274,11 +274,11 @@ export class CreateEditPolicyComponent implements OnInit, OnDestroy {
       });
   }
 
-  onSubmit(form: NgForm) {
+  onSubmit() {
     this.hideContent = true;
     this.policyLoader = true;
-    console.log(form.value, "Form");
-    this.buildCreatepolicyModel(form.value);
+    console.log("Form");
+    this.buildCreatepolicyModel();
   }
 
   ispolicyIdAvailable(policyIdKeyword) {
@@ -313,7 +313,7 @@ export class CreateEditPolicyComponent implements OnInit, OnDestroy {
       });
   }
 
-  private buildCreatepolicyModel(policyForm: any) {
+  private buildCreatepolicyModel() {
     const PolicyModel = Object();
     PolicyModel.policyType = this.selectedPolicyType;
     PolicyModel.policyDisplayName = this.policyDisplayName;
@@ -324,9 +324,9 @@ export class CreateEditPolicyComponent implements OnInit, OnDestroy {
     PolicyModel.severity = this.selectedSeverity;
     PolicyModel.status = this.status?"ENABLED": "DISABLED";
     PolicyModel.category = this.selectedCategory;
-    PolicyModel.policyDesc = policyForm.description;
-    PolicyModel.resolution = policyForm.resolution;
-    PolicyModel.resolutionUrl = policyForm.resolutionUrl;
+    PolicyModel.policyDesc = this.description;
+    PolicyModel.resolution = this.resolution;
+    PolicyModel.resolutionUrl = this.resolutionUrl;
     PolicyModel.assetGroup = this.selectedAssetGroup;
     PolicyModel.policyExecutable = this.policyJarFileName;
     PolicyModel.policyRestUrl = this.policyUrl;
@@ -390,15 +390,6 @@ export class CreateEditPolicyComponent implements OnInit, OnDestroy {
     policyParms.params = this.paramsList;
     policyParms.environmentVariables = this.allEnvironments;
     return JSON.stringify(policyParms);
-  }
-
-  private getpolicyRestUrl(policyForm) {
-    const policyType = policyForm.policyType;
-    if (policyType === 'Serverless') {
-      return policyForm.resolutionUrl;
-    } else {
-      return '';
-    }
   }
 
   onSelectCategory(selectedCategory) {

--- a/webapp/src/app/pacman-features/modules/admin/create-edit-policy/create-edit-policy.component.ts
+++ b/webapp/src/app/pacman-features/modules/admin/create-edit-policy/create-edit-policy.component.ts
@@ -277,7 +277,6 @@ export class CreateEditPolicyComponent implements OnInit, OnDestroy {
   onSubmit() {
     this.hideContent = true;
     this.policyLoader = true;
-    console.log("Form");
     this.buildCreatepolicyModel();
   }
 
@@ -613,6 +612,10 @@ export class CreateEditPolicyComponent implements OnInit, OnDestroy {
       for (let i = this.allPolicyParams.length - 1; i >= 0; i -= 1) {
         if (this.allPolicyParams[i]["isEdit"]) {
           this.hasEditableParams++;
+        }
+        if(this.allPolicyParams[i]["key"].toLowerCase() == "policycategory" || this.allPolicyParams[i]["key"].toLowerCase() == "severity")
+        {
+          continue;
         }
           this.paramsList.push(
             {


### PR DESCRIPTION
removed duplicate params for category and severity by not passing in paramsList while updating

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
