### PR TITLE
feat: Adding Aqua credentials to aws secret manager

### DIFF
--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AquaAccountServiceImpl.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AquaAccountServiceImpl.java
@@ -171,7 +171,7 @@ public class AquaAccountServiceImpl extends AbstractAccountServiceImpl implement
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .withRegion(region).build();
         String secretId=secretManagerPrefix+"/aqua";
-        DeleteSecretRequest deleteRequest=new DeleteSecretRequest().withSecretId(secretId);
+        DeleteSecretRequest deleteRequest=new DeleteSecretRequest().withSecretId(secretId).withForceDeleteWithoutRecovery(true);
         DeleteSecretResult deleteResponse = secretClient.deleteSecret(deleteRequest);
         LOGGER.info("Delete secret response: {} ",deleteResponse);
 
@@ -187,7 +187,7 @@ public class AquaAccountServiceImpl extends AbstractAccountServiceImpl implement
     }
 
     private String getAquaSecret(CreateAccountRequest accountRequest){
-        String template="{\"aquaApiUrl\":\"%s\"\"aquaClientDomainUrl\":\"%s\"\"apiusername\":\"%s\",\"apipassword\":\"%s\"}";
+        String template="{\"aquaApiUrl\":\"%s\",\"aquaClientDomainUrl\":\"%s\",\"apiusername\":\"%s\",\"apipassword\":\"%s\"}";
         return String.format(template,accountRequest.getAquaApiUrl(),accountRequest.getAquaClientDomainUrl(),accountRequest.getAquaApiUser()
                 ,accountRequest.getAquaApiPassword());
 

--- a/jobs/pacman-aqua-enricher/pom.xml
+++ b/jobs/pacman-aqua-enricher/pom.xml
@@ -45,6 +45,22 @@
 			<artifactId>jackson-dataformat-xml</artifactId>
 			<version>2.8.5</version>
 		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk</artifactId>
+			<version>1.12.290</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-secretsmanager</artifactId>
+			<version>1.12.413</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-core</artifactId>
+			<version>1.12.239</version>
+		</dependency>
 
 		<dependency>
 			<groupId>com.paladincloud</groupId>

--- a/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/auth/CredentialProvider.java
+++ b/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/auth/CredentialProvider.java
@@ -1,0 +1,43 @@
+package com.tmobile.cso.pacman.aqua.auth;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
+import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
+
+
+public class CredentialProvider {
+    private static boolean devMode = System.getProperty("PIC_DEV_MODE")!=null;
+
+
+
+    public BasicSessionCredentials getBaseAccountCredentials (String baseAccount, String baseRegion,String roleName) {
+        if (devMode) {
+            String accessKey = System.getProperty("ACCESS_KEY");
+            String secretKey = System.getProperty("SECRET_KEY");
+            BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+            AWSSecurityTokenServiceClientBuilder stsBuilder = AWSSecurityTokenServiceClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(awsCreds)).withRegion(baseRegion);
+            AWSSecurityTokenService sts = stsBuilder.build();
+            AssumeRoleRequest assumeRequest = new AssumeRoleRequest().withRoleArn(getRoleArn(baseAccount, roleName)).withRoleSessionName("pic-base-ro");
+            AssumeRoleResult assumeResult = sts.assumeRole(assumeRequest);
+            return new BasicSessionCredentials(
+                    assumeResult.getCredentials().getAccessKeyId(), assumeResult.getCredentials().getSecretAccessKey(),
+                    assumeResult.getCredentials().getSessionToken());
+
+        } else {
+            AWSSecurityTokenService sts = AWSSecurityTokenServiceClientBuilder.defaultClient();
+            AssumeRoleRequest assumeRequest = new AssumeRoleRequest().withRoleArn(getRoleArn(baseAccount, roleName)).withRoleSessionName("pic-base-ro");
+            AssumeRoleResult assumeResult = sts.assumeRole(assumeRequest);
+            return new BasicSessionCredentials(
+                    assumeResult.getCredentials().getAccessKeyId(), assumeResult.getCredentials().getSecretAccessKey(),
+                    assumeResult.getCredentials().getSessionToken());
+        }
+    }
+
+    private String getRoleArn(String account, String role){
+        return "arn:aws:iam::"+account+":role/"+role;
+    }
+}

--- a/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/jobs/AquaDataImporter.java
+++ b/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/jobs/AquaDataImporter.java
@@ -1,9 +1,12 @@
 package com.tmobile.cso.pacman.aqua.jobs;
 
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.google.gson.JsonObject;
+import com.tmobile.cso.pacman.aqua.auth.CredentialProvider;
 import com.tmobile.cso.pacman.aqua.exception.AquaDataImportException;
 import com.tmobile.cso.pacman.aqua.util.HttpUtil;
 import com.tmobile.cso.pacman.aqua.util.Util;
+import com.tmobile.pacman.commons.secrets.AwsSecretManagerUtil;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -11,13 +14,28 @@ import org.slf4j.LoggerFactory;
 
 public abstract class AquaDataImporter {
 
-  protected static final String BASE_API_URL = System.getProperty("aqua_api_url");
+  protected static String BASE_API_URL = null;
 
-  protected static final String userName = System.getProperty("aqua_username");
+  AwsSecretManagerUtil secretManagerUtil=new AwsSecretManagerUtil();
 
-  protected static final String password = System.getProperty("aqua_password");
+  CredentialProvider credentialProvider=new CredentialProvider();
+
+  protected String secretManagerPrefix=System.getProperty("secret.manager.path");
+
+  /** The Constant DEFAULT_USER. */
+  private static String DEFAULT_USER;
+
+  /** The Constant DEFAULT_PASS. */
+  private static String DEFAULT_PASS;
+
+  protected static String AQUA_CLIENT_DOMAIN_URL;
+
 
   abstract public Map<String, Object> execute();
+
+  protected  String baseAccount =System.getProperty("base.account");
+  protected  String baseRegion =System.getProperty("base.region");
+  protected  String roleName =System.getProperty("s3.role");
 
   /** The api map. */
   Map<String, String> apiMap = null;
@@ -33,13 +51,26 @@ public abstract class AquaDataImporter {
         "/api/v2/risks/vulnerabilities");
     apiMap.put("vm_vulnerabilities", "/api/v2/risks/functions/vulnerabilities");
     apiMap.put("hostassetcount", "/qps/rest/2.0/count/am/hostasset");
+    getAquaInfo();
   }
+
+  private void getAquaInfo() {
+    BasicSessionCredentials credential = credentialProvider.getBaseAccountCredentials(baseAccount, baseRegion, roleName);
+    secretManagerPrefix="paladincloud/secret";
+    String secretData=secretManagerUtil.fetchSecret(secretManagerPrefix+"/aqua",credential,baseRegion);
+    Map<String, String> dataMap = Util.getJsonData(secretData);
+    DEFAULT_USER=dataMap.get("apiusername");
+    DEFAULT_PASS=dataMap.get("apipassword");
+    BASE_API_URL=dataMap.get("aquaApiUrl");
+    AQUA_CLIENT_DOMAIN_URL= dataMap.get("aquaClientDomainUrl");
+  }
+
   public String getBearerToken() throws AquaDataImportException {
     String token = null;
     String tokenUri = BASE_API_URL + apiMap.get("signIn");
     JsonObject inputObject = new JsonObject();
-      inputObject.addProperty("email", userName);
-    inputObject.addProperty("password", password);
+    inputObject.addProperty("email", DEFAULT_USER);
+    inputObject.addProperty("password", DEFAULT_PASS);
     String input = inputObject.toString();
     try {
       String response = HttpUtil.post(tokenUri,input,null , null);

--- a/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/jobs/AquaFunctionVulnerabilityDataImporter.java
+++ b/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/jobs/AquaFunctionVulnerabilityDataImporter.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 public class AquaFunctionVulnerabilityDataImporter extends AquaDataImporter implements Constants {
 
 
-  protected static final String AQUA_CLIENT_DOMAIN_URL = System.getProperty("aqua_client_domain_url");
   protected static final int DEFAULT_PAGE_SIZE = Integer.parseInt(System.getProperty("default_page_size"));
   protected static final String AQUA_VM_VULNERABILITY_API_QUERY_PARAMS = System.getProperty("aqua_vm_vul_query_params");
 

--- a/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/jobs/AquaImageVulnerabilityDataImporter.java
+++ b/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/jobs/AquaImageVulnerabilityDataImporter.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 public class AquaImageVulnerabilityDataImporter extends AquaDataImporter implements Constants {
 
 
-  protected static final String AQUA_CLIENT_DOMAIN_URL = System.getProperty("aqua_client_domain_url");
   protected static final int DEFAULT_PAGE_SIZE = Integer.parseInt(System.getProperty("default_page_size"));
   protected static final String AQUA_IMAGE_VULNERABILITY_API_QUERY_PARAMS = System.getProperty("aqua_image_vul_query_params");
 
@@ -75,6 +74,9 @@ public class AquaImageVulnerabilityDataImporter extends AquaDataImporter impleme
             AQUA_IMAGE_VULNERABILITY_API_QUERY_PARAMS +
             pagination;
         Map<String, Object> response = ((Map<String, Object>)gson.fromJson(HttpUtil.get(vulnerabilityURI, token), Map.class));
+        if(null==response || response.isEmpty()){
+          throw new AquaDataImportException("Failed to fetch or No  vulnerability data found!!!");
+        }
         double currentCount = (Double) response.get("page") * (Double) response.get("pagesize");
         if (currentCount >= (Double) response.get("count")) {
           isLastPage = true;

--- a/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/jobs/AquaVMVulnerabilityDataImporter.java
+++ b/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/jobs/AquaVMVulnerabilityDataImporter.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 public class AquaVMVulnerabilityDataImporter extends AquaDataImporter implements Constants {
 
 
-  protected static final String AQUA_CLIENT_DOMAIN_URL = System.getProperty("aqua_client_domain_url");
   protected static final int DEFAULT_PAGE_SIZE = Integer.parseInt(System.getProperty("default_page_size"));
   protected static final String AQUA_VM_VULNERABILITY_API_QUERY_PARAMS = System.getProperty("aqua_vm_vul_query_params");
 

--- a/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/util/Util.java
+++ b/jobs/pacman-aqua-enricher/src/main/java/com/tmobile/cso/pacman/aqua/util/Util.java
@@ -1,11 +1,13 @@
 package com.tmobile.cso.pacman.aqua.util;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -15,6 +17,7 @@ import org.apache.http.entity.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.BaseEncoding;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -44,6 +47,18 @@ public class Util {
             log.error("Error in base64Decode",e);
             return "";
         }
+    }
+
+    public static Map<String,String> getJsonData(String jsonString){
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, String> map= Collections.emptyMap();
+        try {
+            // convert JSON string to Map
+            map = mapper.readValue(jsonString, Map.class);
+        } catch (IOException e) {
+            log.error("Error in parsing json data",e);
+        }
+        return map;
     }
     
     /**


### PR DESCRIPTION
# Description

Persist Aqua sensitive information in AWS secret manager 


Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?


- [ ] Add new aqua account in Dev
- [ ] Tested By retrieving the credentials and collect aqua vulnerabilities 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
