### PR TITLE
feat(notifications): filter only string values

### DIFF
--- a/webapp/src/app/pacman-features/modules/notifications/prop-value-link.directive.ts
+++ b/webapp/src/app/pacman-features/modules/notifications/prop-value-link.directive.ts
@@ -13,7 +13,7 @@ import {
     selector: '[appPropValueLink]',
 })
 export class PropValueLinkDirective implements OnInit {
-    @Input() appPropValueLink = '';
+    @Input() appPropValueLink: unknown;
     @Output() innerNavigate = new EventEmitter<string>();
 
     @HostListener('click', ['$event'])
@@ -30,6 +30,9 @@ export class PropValueLinkDirective implements OnInit {
     constructor(private el: ElementRef<HTMLElement>, private renderer: Renderer2) {}
 
     ngOnInit(): void {
+        if (typeof this.appPropValueLink !== 'string') {
+            return;
+        }
         const el = this.el.nativeElement;
         const prop = 'innerHTML';
         if (this.appPropValueLink.match(this.LINK_REGEX)) {


### PR DESCRIPTION
# Description

If an input value in key-value view is not a string, `match is not a function` error was thrown

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
