### PR TITLE
[MVP2023-145] feat: add accountid and accountname fields for gcp and …

### DIFF
--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/DiagnosticSettingsCollector.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/DiagnosticSettingsCollector.java
@@ -40,7 +40,7 @@ public class DiagnosticSettingsCollector {
                 diagnosticSettingVH.setId(diagnosticSetting.getAsJsonObject().getAsJsonPrimitive("id").getAsString());
                 diagnosticSettingVH.setName(diagnosticSetting.getAsJsonObject().getAsJsonPrimitive("name").getAsString());
                 diagnosticSettingVH.setSubscriptionName(subscription.getSubscriptionName());
-                diagnosticSettingVH.setSubscription(subscription.toString());
+                diagnosticSettingVH.setSubscription(subscription.getSubscriptionId());
                 diagnosticSettingVH.setResourceGroupName(subscription.getResourceGroupName());
                 diagnosticSettingVH.setSubscriptionId(subscription.getSubscriptionId());
                 diagnosticSettingVH.setRegion(subscription.getRegion());

--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/SecurityContactsCollector.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/SecurityContactsCollector.java
@@ -80,7 +80,7 @@ public class SecurityContactsCollector {
 
             for(JsonElement autoProvisioningElement:autoProvisioningObjects){
                 AutoProvisioningSettingsVH autoProvisioningSettingsVH=new AutoProvisioningSettingsVH();
-                autoProvisioningSettingsVH.setSubscription(subscription.toString());
+                autoProvisioningSettingsVH.setSubscription(subscription.getSubscriptionId());
                 autoProvisioningSettingsVH.setSubscriptionName(subscription.getSubscriptionName());
                 JsonObject autoProvisioningObject=autoProvisioningElement.getAsJsonObject();
                 String id=autoProvisioningObject.get(ID).getAsString();

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/EntityManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/EntityManager.java
@@ -188,6 +188,20 @@ public class EntityManager implements Constants {
             entityInfo.put("_docid", docId);
             entityInfo.put("_entity", "true");
             entityInfo.put("_entitytype", _type);
+
+            if(entityInfo.containsKey("subscriptionName")){
+                entityInfo.put("accountname",entityInfo.get("subscriptionName"));
+            }
+            else if(entityInfo.containsKey("projectName")){
+                entityInfo.put("accountname",entityInfo.get("projectName"));
+            }
+            if(entityInfo.containsKey("subscription")){
+                entityInfo.put("accountid",entityInfo.get("subscription"));
+            }
+            else if(entityInfo.containsKey("projectId")){
+                entityInfo.put("accountid",entityInfo.get("projectId"));
+            }
+
             if (currentInfo != null && !currentInfo.isEmpty()) {
                 Map<String, String> _currInfo = currentInfo.get(docId);
                 if (_currInfo != null) {


### PR DESCRIPTION
…azure assets

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Add accountid and accountname fields for gcp and azure resources. This is to help filters api to pick accountids of gcp and azure. Presently they are stored with different field names like projectid and subscription.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
