### PR TITLE
fix(sidenav-content): pushed when drawer mode change to over

### DIFF
--- a/webapp/src/app/post-login-app/post-login-app.component.html
+++ b/webapp/src/app/post-login-app/post-login-app.component.html
@@ -27,16 +27,16 @@
         >
             <img src="/assets/icons/Path.svg" />
         </button>
-        <mat-sidenav-container autosize [hasBackdrop]="false">
+        <mat-sidenav-container [hasBackdrop]="false" #matSidenavContainer autosize>
             <mat-sidenav
                 #sidenav
-                [class.expanded-sidenav]="isExpanded"
                 [class.collapsed-sidenav]="!isExpanded"
+                [class.expanded-sidenav]="isExpanded"
                 [mode]="mode"
-                opened="true"
                 (mouseenter)="mouseenter()"
                 (mouseleave)="mouseleave()"
                 disableClose
+                opened
             >
                 <div class="contextual-menu-container">
                     <app-contextual-menu
@@ -47,7 +47,11 @@
                 </div>
             </mat-sidenav>
             <mat-sidenav-content>
-                <div class="contextual-content-container" [appScrollTracker]="'main-sidenav'">
+                <div
+                    class="contextual-content-container"
+                    [style.paddingLeft.px]="containerModeOverOffset"
+                    [appScrollTracker]="'main-sidenav'"
+                >
                     <router-outlet></router-outlet>
                 </div>
             </mat-sidenav-content>

--- a/webapp/src/app/post-login-app/post-login-app.component.ts
+++ b/webapp/src/app/post-login-app/post-login-app.component.ts
@@ -12,21 +12,22 @@
  * limitations under the License.
  */
 
-import { Component, OnDestroy, OnInit } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
-import { AssetGroupObservableService } from "../core/services/asset-group-observable.service";
-import { Subscription } from "rxjs";
-import { LoggerService } from "../shared/services/logger.service";
-import { DataCacheService } from "../core/services/data-cache.service";
-import { DownloadService } from "../shared/services/download.service";
-import { DomainTypeObservableService } from "../core/services/domain-type-observable.service";
-import { ThemeObservableService } from "../core/services/theme-observable.service";
-import { WorkflowService } from "../core/services/workflow.service";
-import { PermissionGuardService } from "../core/services/permission-guard.service";
-import { WindowExpansionService } from "../core/services/window-expansion.service";
-import { SnackbarComponent } from "../shared/components/molecules/snackbar/snackbar.component";
-import { NotificationObservableService } from "../shared/services/notification-observable.service";
+import { Component, OnDestroy, OnInit, ViewChild } from "@angular/core";
+import { MatDrawerMode, MatSidenavContainer } from "@angular/material/sidenav";
 import { MatSnackBar } from "@angular/material/snack-bar";
+import { ActivatedRoute, Router } from "@angular/router";
+import { Subscription } from "rxjs";
+import { AssetGroupObservableService } from "../core/services/asset-group-observable.service";
+import { DataCacheService } from "../core/services/data-cache.service";
+import { DomainTypeObservableService } from "../core/services/domain-type-observable.service";
+import { PermissionGuardService } from "../core/services/permission-guard.service";
+import { ThemeObservableService } from "../core/services/theme-observable.service";
+import { WindowExpansionService } from "../core/services/window-expansion.service";
+import { WorkflowService } from "../core/services/workflow.service";
+import { SnackbarComponent } from "../shared/components/molecules/snackbar/snackbar.component";
+import { DownloadService } from "../shared/services/download.service";
+import { LoggerService } from "../shared/services/logger.service";
+import { NotificationObservableService } from "../shared/services/notification-observable.service";
 
 declare var Offline: any;
 
@@ -36,6 +37,7 @@ declare var Offline: any;
   styleUrls: ["./post-login-app.component.css"],
 })
 export class PostLoginAppComponent implements OnInit, OnDestroy {
+  @ViewChild('matSidenavContainer') sidenavContainer: MatSidenavContainer;
   navigationDetails: any;
   domainList: string;
   queryParameters: any = {};
@@ -52,9 +54,10 @@ export class PostLoginAppComponent implements OnInit, OnDestroy {
   private reloadTimeout;
   isOffline = false;
   isExpanded = true;
-  mode = 'side';
+  mode: MatDrawerMode = 'side';
   sidenavExpanderLeft = 250;
   rotationVar = 'rotate(180deg)';
+  containerModeOverOffset = 0;
 
   sidenavExpanderClicked() {
     this.isExpanded = !this.isExpanded;
@@ -75,6 +78,7 @@ export class PostLoginAppComponent implements OnInit, OnDestroy {
       this.sidenavExpanderLeft = 250;
       this.rotationVar = 'rotate(180deg)';
       this.mode = "over";
+      this.containerModeOverOffset = this.sidenavContainer._contentMargins.left;
       this.windowExpansionService.setExpansionStatus(this.isExpanded);
     }
   }
@@ -85,6 +89,7 @@ export class PostLoginAppComponent implements OnInit, OnDestroy {
       this.sidenavExpanderLeft = 70;
       this.rotationVar = 'rotate(0)';
       this.mode = "side";
+      this.containerModeOverOffset = 0;
       this.windowExpansionService.setExpansionStatus(this.isExpanded);
     }
   }


### PR DESCRIPTION
# Description

Hovering on a collapsed menu pushes the main content

before:

https://github.com/PaladinCloud/CE/assets/4422785/da37adaa-a6d4-44e6-95fd-d4a38ceb3052

after:

https://github.com/PaladinCloud/CE/assets/4422785/f0cd6b18-c649-4c2b-9471-c35a9b187d37

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
