### PR TITLE
Fix: [CORE-828] [CORE-835] AWS resource unique id issue

### DIFF
--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/EntityAssociationManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/EntityAssociationManager.java
@@ -37,6 +37,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,16 +109,22 @@ public class EntityAssociationManager implements Constants {
 
                             obj.put("_loaddate", loaddate);
                             obj.put(Constants.DOC_TYPE, childTypeES);
+                            String parentID = Util.concatenate(obj, key.split(","), "_");
+                            if("aws".equalsIgnoreCase(dataSource)) {
+                            	if(Arrays.asList(key.split(",")).contains("accountid")) {
+                            		parentID = dataSource+"_"+type+"_"+parentID;
+                            	}
+                            }
                             Map<String, Object> relMap = new HashMap<>();
                             relMap.put("name", childTypeES);
-                            relMap.put("parent", Util.concatenate(obj, key.split(","), "_"));
+                            relMap.put("parent", parentID);
                             obj.put(type + "_relations", relMap);
                         });
 
                         LOGGER.info("Collected :  {}", entities.size());
                         if (!entities.isEmpty()) {
                             ErrorManager.getInstance(dataSource).handleError(indexName, childTypeES, loaddate, errorList, false);
-                            ESManager.uploadData(indexName, childTypeES, entities, key.split(","));
+                            ESManager.uploadData(indexName,type, childTypeES, entities, key.split(","), dataSource);
                             ESManager.deleteOldDocuments(indexName, childTypeES, "_loaddate.keyword",
                                     loaddate);
                         }

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/EntityManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/EntityManager.java
@@ -112,7 +112,7 @@ public class EntityManager implements Constants {
                     String idColumn = ConfigManager.getIdForType(datasource, type);
 	                String[] keysArray = keys.split(",");
 	                
-	                prepareDocs(currentInfo, entities, tags, overridableInfo, overridesMap, idColumn, keysArray, type);
+	                prepareDocs(currentInfo, entities, tags, overridableInfo, overridesMap, idColumn, keysArray, type,datasource);
 	                Map<String,Long> errUpdateInfo = ErrorManager.getInstance(datasource).handleError(indexName,type,loaddate,errorList,true);
 	                Map<String, Object> uploadInfo = ESManager.uploadData(indexName, type, entities, loaddate);
                     //ESManager.removeViolationForDeletedAssets(entities, indexName);
@@ -181,14 +181,21 @@ public class EntityManager implements Constants {
      */
     private  void prepareDocs(Map<String, Map<String, String>> currentInfo, List<Map<String, Object>> entities,
             List<Map<String, String>> tags, List<Map<String, String>> overridableInfo,
-            Map<String, List<Map<String, String>>> overridesMap, String idColumn, String[] _keys, String _type) {
+            Map<String, List<Map<String, String>>> overridesMap, String idColumn, String[] _keys, String _type, String dataSource) {
         entities.parallelStream().forEach(entityInfo -> {
             String id = entityInfo.get(idColumn).toString();
             String docId = Util.concatenate(entityInfo, _keys, "_");
             entityInfo.put("_resourceid", id);
+            if("aws".equalsIgnoreCase(dataSource)) {
+            	if(Arrays.asList(_keys).contains("accountid")) {
+            		docId = dataSource+"_"+_type+"_"+docId;
+            	}
+            }
             entityInfo.put("_docid", docId);
             entityInfo.put("_entity", "true");
             entityInfo.put("_entitytype", _type);
+            
+            
 
             if(entityInfo.containsKey("subscriptionName")){
                 entityInfo.put("accountname",entityInfo.get("subscriptionName"));

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/es/ESManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/es/ESManager.java
@@ -845,6 +845,10 @@ public class ESManager implements Constants {
     		updateJson.append(",{\"match\":{\"region.keyword\":\"");
     		updateJson.append(region);
     		updateJson.append("\"}}");
+    	}if(!Strings.isNullOrEmpty(type)) {
+    		updateJson.append(",{\"match\":{\"docType.keyword\":\"");
+    		updateJson.append(type);
+    		updateJson.append("\"}}");
     	}
     	if(checkLatest){
     		updateJson.append(",{\"match\":{\"latest\":true }}");

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/es/ESManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/es/ESManager.java
@@ -108,7 +108,7 @@ public class ESManager implements Constants {
             int i = 0;
             for (Map<String, Object> doc : docs) {
 
-                String id = Util.concatenate(doc, _keys, "_");
+                String id = (String)doc.get("_docid");
                 StringBuilder _doc = new StringBuilder(createESDoc(doc));
                 _doc.deleteCharAt(_doc.length() - 1);
                 _doc.append(",\"latest\":true,\"_loaddate\":\"" + loaddate + "\" }");
@@ -745,7 +745,7 @@ public class ESManager implements Constants {
      * @param docs the docs
      * @param parentKey the parent key
      */
-    public static void uploadData(String index, String type, List<Map<String, Object>> docs, String[] parentKey) {
+    public static void uploadData(String index, String parentType, String type, List<Map<String, Object>> docs, String[] key, String dataSource) {
         String actionTemplate = "{ \"index\" : { \"_index\" : \"%s\" , \"routing\" : \"%s\" } }"; // added
                                                                                                                        // _parent
                                                                                                                        // node
@@ -758,7 +758,12 @@ public class ESManager implements Constants {
             for (Map<String, Object> doc : docs) {
 
                 String _doc = new Gson().toJson(doc);
-                String parent = Util.concatenate(doc, parentKey, "_");
+                String parent = Util.concatenate(doc, key, "_");
+                if("aws".equalsIgnoreCase(dataSource)) {
+                	if(Arrays.asList(key).contains("accountid")) {
+                		parent = dataSource+"_"+parentType+"_"+parent;
+                	}
+                }
                 bulkRequest.append(String.format(actionTemplate, index, parent)).append("\n");
                 bulkRequest.append(_doc).append("\n");
                 i++;

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/es/ESManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/es/ESManager.java
@@ -850,7 +850,8 @@ public class ESManager implements Constants {
     		updateJson.append(",{\"match\":{\"region.keyword\":\"");
     		updateJson.append(region);
     		updateJson.append("\"}}");
-    	}if(!Strings.isNullOrEmpty(type)) {
+    	}
+    	if(!Strings.isNullOrEmpty(type)) {
     		updateJson.append(",{\"match\":{\"docType.keyword\":\"");
     		updateJson.append(type);
     		updateJson.append("\"}}");

--- a/jobs/pacman-data-shipper/src/test/java/com/tmobile/cso/pacman/datashipper/es/ESManagerTest.java
+++ b/jobs/pacman-data-shipper/src/test/java/com/tmobile/cso/pacman/datashipper/es/ESManagerTest.java
@@ -184,7 +184,8 @@ public class ESManagerTest {
         when(response.getStatusLine()).thenReturn(sl);
         
         String parent = "parent";
-        esManager.uploadData("index", "type", docs,parent.split(","));
+        String dataSource = "aws";
+        esManager.uploadData("index", "parent_type","type", docs,parent.split(","), dataSource);
     }
     
     @SuppressWarnings({ "unchecked", "static-access" })


### PR DESCRIPTION
# Description

ALL AWS resource  which not configured with ARN  are now using the created with combination of cloud type, asset type, account id, region, resource id , 

Fixes # [CORE-828] [CORE-835]

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki


[CORE-828]: https://paladincloud.atlassian.net/browse/CORE-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-835]: https://paladincloud.atlassian.net/browse/CORE-835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ