### PR TITLE
bug:[CUS-110]Policy "Deny Public Access to User Datagram Protocol (UD…

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/NSGRule/PublicAccessforConfiguredPort.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/NSGRule/PublicAccessforConfiguredPort.java
@@ -122,6 +122,7 @@ public class PublicAccessforConfiguredPort extends BasePolicy {
                                 .get(PacmanRuleConstants.PROTOCOL).getAsString();
                         JsonArray destinationPortRanges=nBoundarySecurityDataItem.getAsJsonObject()
                                 .get(PacmanRuleConstants.DESTINATIONPORTRANGES).getAsJsonArray();
+                        String access = nBoundarySecurityDataItem.getAsJsonObject().get("access").getAsString();
 
                         if (sourceAddressPrefixes != null && (protocol.equalsIgnoreCase(validateProtocol)||protocol.equalsIgnoreCase(PacmanRuleConstants.PORT_ANY)
                                 && checkDestinationPort(destinationPortRanges,validatePort))) {
@@ -133,9 +134,10 @@ public class PublicAccessforConfiguredPort extends BasePolicy {
                                         || sourceAddressPrefixes.get(srcAdsIndex).getAsString()
                                         .equals(PacmanRuleConstants.INTERNET)) {
                                     logger.info("Port: {} has unrestricted Access", ((Object[]) validatePort));
-                                    validationResult = false;
-                                    break;
-
+                                    if(access.equalsIgnoreCase("allow")){
+                                        validationResult = false;
+                                        break;
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
…P)" is showing incorrect violations

# Description

to check for violation, the access attribute needs to be checked in order to raise a violation in case public access is allowed for UDP policy

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
