### PR TITLE
fix:[CORE-1315]Ignore data dog alerts for Trusted advisor

### DIFF
--- a/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/util/InventoryUtil.java
+++ b/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/util/InventoryUtil.java
@@ -2001,7 +2001,12 @@ public class InventoryUtil {
 				}
 			}
 		}catch(AWSSupportException e){
-			log.info(expPrefix +", \"cause\":\"" +e.getMessage()+"\"}");
+			if(e.getErrorMessage().equals("Amazon Web Services Premium Support Subscription is required to use this service."))
+				log.info(expPrefix +", \"cause\":\"" +e.getMessage()+"\"}");
+			else {
+				log.error(expPrefix +", \"cause\":\"" +e.getMessage()+"\"}");
+				ErrorManageUtil.uploadError(accountId,"","checks",e.getMessage());
+			}
 		}catch (Exception e)
 		{
 			log.error(expPrefix +", \"cause\":\"" +e.getMessage()+"\"}");

--- a/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/util/InventoryUtil.java
+++ b/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/util/InventoryUtil.java
@@ -40,6 +40,7 @@ import com.amazonaws.services.securityhub.AWSSecurityHub;
 import com.amazonaws.services.securityhub.AWSSecurityHubClientBuilder;
 import com.amazonaws.services.securityhub.model.DescribeHubRequest;
 import com.amazonaws.services.securityhub.model.DescribeHubResult;
+import com.amazonaws.services.support.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
@@ -322,12 +323,6 @@ import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
 import com.amazonaws.services.sqs.model.ListQueueTagsRequest;
 import com.amazonaws.services.support.AWSSupport;
 import com.amazonaws.services.support.AWSSupportClientBuilder;
-import com.amazonaws.services.support.model.DescribeTrustedAdvisorCheckResultRequest;
-import com.amazonaws.services.support.model.DescribeTrustedAdvisorCheckResultResult;
-import com.amazonaws.services.support.model.DescribeTrustedAdvisorChecksRequest;
-import com.amazonaws.services.support.model.DescribeTrustedAdvisorChecksResult;
-import com.amazonaws.services.support.model.RefreshTrustedAdvisorCheckRequest;
-import com.amazonaws.services.support.model.TrustedAdvisorCheckDescription;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -2005,7 +2000,10 @@ public class InventoryUtil {
 					ErrorManageUtil.uploadError(accountId,"","checks",e.getMessage());
 				}
 			}
-		}catch(Exception e){
+		}catch(AWSSupportException e){
+			log.info(expPrefix +", \"cause\":\"" +e.getMessage()+"\"}");
+		}catch (Exception e)
+		{
 			log.error(expPrefix +", \"cause\":\"" +e.getMessage()+"\"}");
 			ErrorManageUtil.uploadError(accountId,"","checks",e.getMessage());
 		}


### PR DESCRIPTION
# Description

Ignore data dog alerts in case customers are not using the Trusted Advisor AWS Data collector

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
