### PR TITLE
fix:[CORE-1304] handle NPE when fetching addOnProfiles() for kubernet…

### DIFF
--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/KubernetesServicesCollector.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/KubernetesServicesCollector.java
@@ -64,9 +64,17 @@ public class KubernetesServicesCollector {
                     String kubernatesClusterName = kubernetesClusterObject.get("name").getAsString()!=null && !kubernetesClusterObject.get("name").getAsString().isEmpty()?kubernetesClusterObject.get("name").getAsString():"";
                     logger.info("kubernatesClusterName: {}", kubernatesClusterName);
                     kubernetesClustersVH.setName(kubernatesClusterName);
-                    if(kubernetesCluster.addonProfiles()!=null && kubernetesCluster.addonProfiles().get("kubeDashboard")!=null) {
-                        kubernetesClustersVH.setDashBoardEnabled( kubernetesCluster.addonProfiles().get("kubeDashboard").enabled());
+                    try{
+                        if(kubernetesCluster.addonProfiles()!=null && kubernetesCluster.addonProfiles().get("kubeDashboard")!=null) {
+                            kubernetesClustersVH.setDashBoardEnabled( kubernetesCluster.addonProfiles().get("kubeDashboard").enabled());
+                        }
                     }
+                    catch(Exception exception){
+                        //Data alert will not be published for the below error.
+                        logger.error(" Following error occurred while fetching add on profiles for kubernetes cluster - {}, This can be due to no addOnProfiles" +
+                                "present for cluster. ",exception.getMessage());
+                    }
+
                     kubernetesClustersVH.setSubscription(subscription.getSubscriptionId());
                     kubernetesClustersVH.setSubscriptionName(subscription.getSubscriptionName());
                     kubernetesClustersVH.setRegion(Util.getRegionValue(subscription,kubernetesClusterObject.get("location").getAsString()));


### PR DESCRIPTION
…es cluster in azure collector job

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Fixes # (issue)

1. In kubernetesServicesCollector.java file, addOnProfiles() method is throwing NPE for any cluster which don't have add on profiles. Approach to handle this issue is catch the exception and do nothing. Let other attributes be collected for the cluster.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
