### PR TITLE
fix:[CORE-1379] handle noentityfound exception for iam policies

### DIFF
--- a/commons/pac-batch-commons/src/main/java/com/tmobile/pacman/commons/PacmanSdkConstants.java
+++ b/commons/pac-batch-commons/src/main/java/com/tmobile/pacman/commons/PacmanSdkConstants.java
@@ -277,6 +277,8 @@ public interface PacmanSdkConstants {
 	/** The status unknown. */
 	String STATUS_UNKNOWN="unknown";
 
+	String STATUS_UNKNOWN_MESSAGE = "unable to determine for this resource";
+
 	/** The error desc key. */
 	String ERROR_DESC_KEY = "errorDesc";
 

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/iam/IAMRoleWithUnapprovedAccessRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/iam/IAMRoleWithUnapprovedAccessRule.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.amazonaws.services.identitymanagement.model.NoSuchEntityException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -149,9 +150,15 @@ public class IAMRoleWithUnapprovedAccessRule extends BasePolicy {
 				}
 			}
 
-		} catch (Exception e) {
-			logger.error(PacmanRuleConstants.UNABLE_TO_GET_CLIENT, e);
-			throw new InvalidInputException(PacmanRuleConstants.UNABLE_TO_GET_CLIENT, e);
+		}
+		catch(NoSuchEntityException exception){
+			logger.error("NoSuchEntityException thrown..", exception);
+			return new PolicyResult(PacmanSdkConstants.STATUS_UNKNOWN, PacmanSdkConstants.STATUS_UNKNOWN_MESSAGE,
+					annotation);
+		}
+		catch (Exception e) {
+				logger.error(PacmanRuleConstants.UNABLE_TO_GET_CLIENT, e);
+				throw new InvalidInputException(PacmanRuleConstants.UNABLE_TO_GET_CLIENT, e);
 		}
 		logger.debug("========IAMRoleWithUnapprovedAccessRule ended=========");
 		return new PolicyResult(PacmanSdkConstants.STATUS_SUCCESS, PacmanRuleConstants.SUCCESS_MESSAGE);


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Fixes # (issue)

1. When NoSuchEntityFoundException is thrown from class IAMRoleWithUnapprovedAccessRule.java(which affects 3 policies), exception is caught and validation is assigned 'unknown' status. Data alert is not published.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
