### PR TITLE
fix:[CORE-1454] asset type and cloud type not returned in assets api …

### DIFF
--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/repository/AssetRepositoryImpl.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/repository/AssetRepositoryImpl.java
@@ -1247,7 +1247,7 @@ public class AssetRepositoryImpl implements AssetRepository {
                     "subnetid", "instancetype", AssetConstants.ACCOUNT_ID, "tags", AssetConstants.ACCOUNT_NAME, "iaminstanceprofilearn",
                     Constants.STATE_NAME, "monitoringstate", "hostid", "statereasoncode", "virtualizationtype",
                     "rootdevicename", "keyname", "kernelid", Constants.STATE_NAME, "hypervisor", "architecture", "tenancy",
-                    "launchtime", "platform"), null);
+                    "launchtime", "platform","docType","_cloudType"), null);
         } catch (Exception e) {
             LOGGER.error("Exception in getEc2ResourceDetail ",e);
             throw new DataException(e);


### PR DESCRIPTION
…for ec2 asset details

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Fixes # (issue)

Add assettype and cloudtype attributes to asset details api for ec2 assets.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
