### PR TITLE
fix:[CORE-1557] Ops alert qualys issue

### DIFF
--- a/jobs/pacman-qualys-enricher/src/main/java/com/tmobile/cso/pacman/qualys/Main.java
+++ b/jobs/pacman-qualys-enricher/src/main/java/com/tmobile/cso/pacman/qualys/Main.java
@@ -69,7 +69,8 @@ public class Main {
             errorInfo =  new KBDataImporter().execute();
             break;
         }
-        if(!errorInfo.isEmpty()){
+        ArrayList errors= (ArrayList) errorInfo.get("errors");
+        if(!errors.isEmpty()){
             //Below logger message is used by datadog to create notification in slack
             log.error("Error occurred in atleast one collector for jobId : {}",jobHint);
         }

--- a/jobs/pacman-qualys-enricher/src/main/java/com/tmobile/cso/pacman/qualys/jobs/HostAssetDataImporter.java
+++ b/jobs/pacman-qualys-enricher/src/main/java/com/tmobile/cso/pacman/qualys/jobs/HostAssetDataImporter.java
@@ -15,6 +15,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.tmobile.cso.pacman.qualys.exception.UnAuthorisedException;
+import com.tmobile.pacman.commons.dto.ErrorVH;
+import com.tmobile.pacman.commons.dto.PermissionVH;
 import org.apache.http.ParseException;
 import org.joda.time.LocalDate;
 import org.slf4j.Logger;
@@ -117,9 +119,17 @@ public class HostAssetDataImporter extends QualysDataImporter implements Constan
         {
             Map<String,String> errorMap = new HashMap<>();
             errorMap.put(ERROR, "Error fetching host assets");
-            errorMap.put(ERROR_TYPE, FATAL);
+            errorMap.put(ERROR_TYPE,FAILED);
             errorMap.put(EXCEPTION, e.getMessage());
             errorList.add(errorMap);
+            List<PermissionVH> permissionVHList=new ArrayList<>();
+            PermissionVH permissionVH=new PermissionVH();
+            ErrorVH errorVH=new ErrorVH();
+            errorVH.setException(e.getMessage());
+            errorVH.setType("ec2");
+            permissionVH.setAccountNumber("Qualys-connector");
+            permissionVHList.add(permissionVH);
+//            NotificationPermissionUtils.triggerNotificationsForPermissionDenied(permissionVHList,"Qualys");
         }catch (Exception e) {
             LOGGER.error("Error fetching host assets ", e);
             Map<String,String> errorMap = new HashMap<>();

--- a/jobs/pacman-qualys-enricher/src/main/java/com/tmobile/cso/pacman/qualys/util/ErrorManageUtil.java
+++ b/jobs/pacman-qualys-enricher/src/main/java/com/tmobile/cso/pacman/qualys/util/ErrorManageUtil.java
@@ -19,11 +19,13 @@ public class ErrorManageUtil implements Constants{
 
     public static Map<String,Object> formErrorCode(List<Map<String,String>> errorList) {
         Map<String,Object> errorCode = new HashMap<>();
+        //to do write error file
+        
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
         errorCode.put("endTime", sdf.format(new Date()));
         
         String status = "";
-        
+        omitOpsAlert(errorList);
         List<Map<String,Object>> errors = new ArrayList<>();
         if(!errorList.isEmpty()) {
             for(Map<String, String> errorDetail :errorList) {
@@ -49,5 +51,15 @@ public class ErrorManageUtil implements Constants{
         errorCode.put("errors", errors);
         errorCode.put("status", status);
         return errorCode;
+    }
+
+    private static void omitOpsAlert(List<Map<String, String>> errorList) {
+        List<Map<String, String>> copyErrorList=new ArrayList<>(errorList);
+        for(Map<String, String> error:copyErrorList)
+        {
+            if(error.get("exception").contains("UnAuthorisedException")) {
+                errorList.remove(error);
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description

Ops alert should not be generated after user is notified of authentication issue

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the qualys asset importer in saasdev

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
