### PR TITLE
[PLG-315] Multiple tenable plugins per AWS base account

### DIFF
--- a/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/Constants.java
+++ b/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/Constants.java
@@ -15,9 +15,6 @@
  ******************************************************************************/
 package com.tmobile.cso.pacman.tenable;
 
-/**
- * The Interface Constants.
- */
 public class Constants {
 
     // TODO: Set to true to get detailed debug logs
@@ -39,4 +36,5 @@ public class Constants {
     private Constants() {
         throw new IllegalStateException("Constants is a utility class");
     }
+
 }

--- a/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/Main.java
+++ b/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/Main.java
@@ -75,4 +75,5 @@ public class Main {
             log.warn("Job hint is not supplied!");
         }
     }
+
 }

--- a/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/MainUtil.java
+++ b/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/MainUtil.java
@@ -19,21 +19,19 @@ import java.util.Map;
 
 import com.tmobile.cso.pacman.tenable.util.ConfigUtil;
 
-/**
- * The Class MainUtil.
- */
 public class MainUtil {
 
     /**
      * Setup.
      *
-     * @param params            the params
+     * @param params the params
      * @throws Exception the exception
      */
     public static void setup(Map<String, String> params) throws Exception {
-      ConfigUtil.setConfigProperties(params.get(Constants.CONFIG_CREDS));
-      if (!params.isEmpty()) {
-        params.forEach(System::setProperty);
-      }
+        ConfigUtil.setConfigProperties(params.get(Constants.CONFIG_CREDS));
+        if (!params.isEmpty()) {
+            params.forEach(System::setProperty);
+        }
     }
+
 }

--- a/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/jobs/TenableDataImporter.java
+++ b/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/jobs/TenableDataImporter.java
@@ -65,7 +65,8 @@ public abstract class TenableDataImporter {
         String roleName = System.getProperty("s3.role");
 
         BasicSessionCredentials credential = credentialProvider.getBaseAccountCredentials(baseAccount, baseRegion, roleName);
-        String secretData = secretManagerUtil.fetchSecret(secretManagerPrefix + "/tenable", credential, baseRegion);
+        String secretName = secretManagerPrefix + "/" + roleName + "/tenable";
+        String secretData = secretManagerUtil.fetchSecret(secretName, credential, baseRegion);
 
         Map<String, String> dataMap = Util.getJsonData(secretData);
         accessKey = dataMap.get("accessKey");


### PR DESCRIPTION
# Description

Role name has been added into secret name - now it's possible to add Tenable plugin for more that one customer per AWS account.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Only single tenable secret left:
![image](https://github.com/PaladinCloud/CE/assets/133698330/5dc3d72c-f9e1-4543-9b54-94d925052890)
Job is executing well:
![image](https://github.com/PaladinCloud/CE/assets/133698330/ff17329d-f717-4d41-930c-49dc62f9d25b)
Link to job:
https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/26516c3f-bc78-4494-8e8d-5db7137f7f01
