### PR TITLE
fix[CUS-253]: filter out aws managed keys from policy evaluation

### DIFF
--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
@@ -682,4 +682,6 @@ public interface PacmanSdkConstants {
     String ACCOUNT_ID = "accountid";
     String TAGGING_MANDATORY_TAGS = "tagging.mandatoryTags";
     String POLICY_NAME = "policyName";
+    String KEY_MANAGER = "keymanager";
+    String KEY_MANAGER_TYPE_CUSTOMER = "CUSTOMER";
 }

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -234,6 +234,10 @@ public class PolicyExecutor {
             if (!Strings.isNullOrEmpty(policyParam.get(PacmanSdkConstants.RESOURCE_ID)))
                 filter.put(ESUtils.createKeyword(PacmanSdkConstants.RESOURCE_ID),
                         policyParam.get(PacmanSdkConstants.RESOURCE_ID));
+            /** we dont want to evaluate kms - aws managed keys because they are completely managed by AWS and cannot be changed by user */
+            if ("kms".equalsIgnoreCase(policyParam.get(PacmanSdkConstants.TARGET_TYPE))) {
+                filter.put(ESUtils.createKeyword(PacmanSdkConstants.KEY_MANAGER), PacmanSdkConstants.KEY_MANAGER_TYPE_CUSTOMER);
+            }
 
             if (!filter.isEmpty()) {
                 logger.debug("found filters in rule config, resources will be filtered");


### PR DESCRIPTION
# Description

For kms asset type, aws managed keys doesn't need to be evaluated by policies as they cannot be changed by user. So we are filtering out the aws managed kms resources before policy evaluation.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Check the violations for aws kms assets on Violations page, which includes the aws managed keys also
- [x] Remove the old violation data from opensearch index for aws managed keys
- [x] Run the policy engine for the policies related to kms asset 
- [x] check the violations for aws kms assets on Violations page again. Violations related to aws managed keys should not be listed

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
