### PR TITLE
fix:[UIUX-443] used display names for keys in policy params widget

### DIFF
--- a/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.css
+++ b/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.css
@@ -298,8 +298,17 @@
   align-items: center;
   padding: 16px 24px;
   gap: 12px;
-  width: 50%;
   height: 100%;
+}
+
+.params-content .key{
+  flex: 4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.params-content .value{
+  flex: 1;
 }
 
 .column-wrapper {
@@ -322,9 +331,4 @@
 
 .sort-img.sorted {
   transform: rotate(0deg);
-}
-
-.content-wrapper{
-  max-height: 356px;
-  overflow: scroll;
 }

--- a/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.html
+++ b/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.html
@@ -63,20 +63,20 @@
                     <ng-container *ngIf="!paramErrorMessage">
                         <div class="content-header">
                             <div class="column-wrapper-header">
-                                <div class="col">
+                                <div class="col key">
                                     <span class="col-header body-2 low-emphasis">Key</span>
                                 </div>
-                                <div class="col">
+                                <div class="col value">
                                     <span class="col-header body-2 low-emphasis">Value</span>
                                 </div>
                             </div>
                         </div>
                         <div class="content-wrapper">
                                 <div class="column-wrapper" *ngFor="let param of paramsArray">
-                                    <div class="col">
+                                    <div class="col key">
                                         <span class="param-name nowrap-ellipsis" title="{{param.key}}">{{ param.key }}</span>
                                     </div>
-                                    <div class="col">
+                                    <div class="col value">
                                         <span class="param-value nowrap-ellipsis" title="{{param.value}}">{{ param.value == '' ? 'Unknown' : param.value }}</span>
                                     </div>
                                 </div>

--- a/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.ts
+++ b/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.ts
@@ -212,9 +212,9 @@ export class PolicyDetailsComponent implements OnInit, OnDestroy {
               this.paramErrorMessage = 'noDataAvailable';
               return;
             }
-            this.paramsArray = JSON.parse(response.policyParams).params
+            this.paramsArray = (JSON.parse(response.policyParams).params??[])
             .filter(item => item.isEdit && item.isEdit=="true")
-            .map(item => {return {key: item.key, value: item.value}});
+            .map(item => {return {key: item.displayName || item.key, value: item.value}});
             if(this.paramsArray.length==0){
               this.paramErrorMessage = 'noDataAvailable';
             }else{


### PR DESCRIPTION
# Description
Made following changes in policy params widget :
1. Used display names for keys.
2. Increased width of keys.
3. Removed max height and scroll from the widget.

Before changes:
![image](https://github.com/PaladinCloud/EE/assets/97596144/39c019a9-01d5-46ea-9bad-b399d99fcb82)

After changes:
![image](https://github.com/PaladinCloud/EE/assets/97596144/aac2196e-476a-4a50-b5dd-93f103d893a2)


Fixes # (issue)
Policy Params widget in Policy Compliance Screen.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
