### PR TITLE
Removed Tenable URL from request check

### DIFF
--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/TenableAccountServiceImpl.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/TenableAccountServiceImpl.java
@@ -54,16 +54,16 @@ public class TenableAccountServiceImpl extends AbstractAccountServiceImpl implem
 
     @Override
     public AccountValidationResponse validate(CreateAccountRequest accountData) {
-        AccountValidationResponse validateResponse=validateRequest(accountData);
+        AccountValidationResponse validateResponse= validateRequestData(accountData);
         if(validateResponse.getValidationStatus().equalsIgnoreCase(FAILURE)){
             LOGGER.info("Validation failed due to missing parameters");
             return validateResponse;
         }
-        validateTenableAccount(accountData, validateResponse);
+        validateAccountCredentials(accountData, validateResponse);
         return validateResponse;
     }
 
-    private void validateTenableAccount(CreateAccountRequest accountData, AccountValidationResponse validateResponse) {
+    private void validateAccountCredentials(CreateAccountRequest accountData, AccountValidationResponse validateResponse) {
         // Requesting scan that doesn't exist to validate the account data.
         HttpGet request = new HttpGet(Constants.TENABLE_API_URL + "/scans/0");
         String apiKey = "accessKey=" + accountData.getTenableAccessKey() + ";secretKey=" + accountData.getTenableSecretKey() + ";";
@@ -97,7 +97,7 @@ public class TenableAccountServiceImpl extends AbstractAccountServiceImpl implem
     @Override
     public AccountValidationResponse addAccount(CreateAccountRequest accountData) {
         LOGGER.info("Adding new Tenable account....");
-        AccountValidationResponse validateResponse=validateRequest(accountData);
+        AccountValidationResponse validateResponse= validateRequestData(accountData);
         if(validateResponse.getValidationStatus().equalsIgnoreCase(FAILURE)){
             LOGGER.info("Validation failed due to missing parameters");
             return validateResponse;
@@ -128,30 +128,29 @@ public class TenableAccountServiceImpl extends AbstractAccountServiceImpl implem
         return validateResponse;
     }
 
-    private AccountValidationResponse validateRequest(CreateAccountRequest accountData) {
-        AccountValidationResponse response=new AccountValidationResponse();
-        StringBuilder validationErrorDetails=new StringBuilder();
-        String tenableAPIUrl= accountData.getTenableAPIUrl();
-        String tenableAccessKey= accountData.getTenableAccessKey();
-        String tenableSecretKey= accountData.getTenableSecretKey();
+    private AccountValidationResponse validateRequestData(CreateAccountRequest accountData) {
+        AccountValidationResponse response = new AccountValidationResponse();
+        StringBuilder validationErrorDetails = new StringBuilder();
+        String tenableAccessKey = accountData.getTenableAccessKey();
+        String tenableSecretKey = accountData.getTenableSecretKey();
 
-        if(StringUtils.isEmpty(tenableAccessKey)){
-            validationErrorDetails.append(MISSING_MANDATORY_PARAMETER +" Tenable Access Key\n");
+        if (StringUtils.isEmpty(tenableAccessKey)) {
+            validationErrorDetails.append(MISSING_MANDATORY_PARAMETER + " Tenable Access Key\n");
         }
-        if(StringUtils.isEmpty(tenableSecretKey)){
-            validationErrorDetails.append(MISSING_MANDATORY_PARAMETER +" Tenable Secret Key\n");
+
+        if (StringUtils.isEmpty(tenableSecretKey)) {
+            validationErrorDetails.append(MISSING_MANDATORY_PARAMETER + " Tenable Secret Key\n");
         }
-        if(StringUtils.isEmpty(tenableAPIUrl)){
-            validationErrorDetails.append(MISSING_MANDATORY_PARAMETER +" Tenable API URl\n");
-        }
-        String validationError=validationErrorDetails.toString();
-        if(!validationError.isEmpty()){
-            validationError=validationError.replace("\n","");
+
+        String validationError = validationErrorDetails.toString();
+        if (!validationError.isEmpty()) {
+            validationError = validationError.replace("\n", "");
             response.setErrorDetails(validationError);
             response.setValidationStatus(FAILURE);
-        }else {
+        } else {
             response.setValidationStatus(SUCCESS);
         }
+
         return response;
     }
 


### PR DESCRIPTION
# Description

Since Tenable URL is static - it doesn't need to be passed from UI and can be just a global constant

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran admin API and tested locally via postman.

Test results for correct creds:
<img width="898" alt="Screenshot 2023-10-30 at 12 07 11 PM" src="https://github.com/PaladinCloud/CE/assets/133698330/719490cc-d207-4816-beec-2e4ea0f3500e">
Results for wrong creds:
<img width="699" alt="Screenshot 2023-10-30 at 12 08 18 PM" src="https://github.com/PaladinCloud/CE/assets/133698330/2cab94de-90e4-4114-bd4c-22b762ac3110">

