### PR TITLE
fix:[CUS-253]stop collecting aws managed keys

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/TaggingRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/TaggingRule.java
@@ -95,16 +95,6 @@ public class TaggingRule extends BasePolicy {
 
 		if (resourceAttributes!=null) {
 
-			String assetType=resourceAttributes.get("_entitytype");
-
-			if(assetType.equalsIgnoreCase("kms")){
-				String keyManager=resourceAttributes.get("keymanager");
-				// Check if the keyManager is aws
-				if ( keyManager.equalsIgnoreCase("aws")){
-					logger.info(targetType, " ", entityId, " is an AWS Managed Resource and is exempt from mandatory tagging.");
-					return new PolicyResult(PacmanSdkConstants.STATUS_SUCCESS, PacmanRuleConstants.SUCCESS_MESSAGE);
-				}
-			}
 			if(targetType.equalsIgnoreCase(PacmanRuleConstants.TARGET_TYPE_EC2)){
 				if(resourceAttributes.get(PacmanRuleConstants.STATE_NAME).equalsIgnoreCase(PacmanRuleConstants.RUNNING_STATE)||resourceAttributes.get(PacmanRuleConstants.STATE_NAME).equalsIgnoreCase(PacmanRuleConstants.STOPPED_STATE)){
 				missingTags = PacmanUtils.getMissingTagsfromResourceAttribute(mandatoryTagsList,resourceAttributes);

--- a/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/util/InventoryUtil.java
+++ b/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/util/InventoryUtil.java
@@ -2347,9 +2347,13 @@ public class InventoryUtil {
 					if(!regionKeys.isEmpty()) {
 						List<KMSKeyVH> kmsKeysList = new ArrayList<>();
 						for(KeyListEntry key : regionKeys) {
-							KMSKeyVH kmsKey = new KMSKeyVH();
 							try {
 								DescribeKeyResult result = awskms.describeKey(new DescribeKeyRequest().withKeyId(key.getKeyId()));
+								/** we dont want to collect and evaluate kms - aws managed keys for now because they are completely managed by AWS and cannot be changed by user */
+								if("aws".equalsIgnoreCase(result.getKeyMetadata().getKeyManager())) {
+									continue;
+								}
+								KMSKeyVH kmsKey = new KMSKeyVH();
 								kmsKey.setKey(result.getKeyMetadata());
 								try{
 									kmsKey.setTags(awskms.listResourceTags(new ListResourceTagsRequest().withKeyId(key.getKeyId())).getTags());

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -17,43 +17,29 @@
 
 package com.tmobile.pacman.executor;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
-
-import com.tmobile.pacman.commons.autofix.AutoFixManagerFactory;
-import com.tmobile.pacman.commons.autofix.manager.IAutofixManger;
-import com.tmobile.pacman.commons.policy.Annotation;
-import com.tmobile.pacman.commons.policy.PacmanPolicy;
-import com.tmobile.pacman.commons.policy.PolicyResult;
-import com.tmobile.pacman.commons.utils.Constants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
-
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.tmobile.pacman.common.PacmanSdkConstants;
+import com.tmobile.pacman.commons.autofix.AutoFixManagerFactory;
+import com.tmobile.pacman.commons.autofix.manager.IAutofixManger;
+import com.tmobile.pacman.commons.policy.Annotation;
+import com.tmobile.pacman.commons.policy.PolicyResult;
+import com.tmobile.pacman.commons.utils.Constants;
 import com.tmobile.pacman.dto.IssueException;
 import com.tmobile.pacman.integrations.slack.SlackMessageRelay;
 import com.tmobile.pacman.publisher.impl.AnnotationPublisher;
 import com.tmobile.pacman.reactors.PacEventHandler;
 import com.tmobile.pacman.service.ExceptionManager;
 import com.tmobile.pacman.service.ExceptionManagerImpl;
-import com.tmobile.pacman.util.AuditUtils;
-import com.tmobile.pacman.util.CommonUtils;
-import com.tmobile.pacman.util.ESUtils;
-import com.tmobile.pacman.util.ProgramExitUtils;
-import com.tmobile.pacman.util.ReflectionUtils;
-import com.tmobile.pacman.util.PolicyExecutionUtils;
-import com.tmobile.pacman.util.NotificationUtils;
+import com.tmobile.pacman.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 
 // TODO: Auto-generated Javadoc
@@ -234,10 +220,6 @@ public class PolicyExecutor {
             if (!Strings.isNullOrEmpty(policyParam.get(PacmanSdkConstants.RESOURCE_ID)))
                 filter.put(ESUtils.createKeyword(PacmanSdkConstants.RESOURCE_ID),
                         policyParam.get(PacmanSdkConstants.RESOURCE_ID));
-            /** we dont want to evaluate kms - aws managed keys because they are completely managed by AWS and cannot be changed by user */
-            if ("kms".equalsIgnoreCase(policyParam.get(PacmanSdkConstants.TARGET_TYPE))) {
-                filter.put(ESUtils.createKeyword(PacmanSdkConstants.KEY_MANAGER), PacmanSdkConstants.KEY_MANAGER_TYPE_CUSTOMER);
-            }
 
             if (!filter.isEmpty()) {
                 logger.debug("found filters in rule config, resources will be filtered");


### PR DESCRIPTION
# Description

The issue was due to evaluating the AWS-managed keys which are not editable by the user. The fix will stop collecting the AWS-managed keys, so only the customer-managed keys will be evaluated by kms policies.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Prior to the fix, running the aws collector job, we can see all the aws managed keys also in the assets
- [x] After the fix, running the aws collector job, we will see only the customer managed keys in the assets

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
