### PR TITLE
revert:[CUS-253]filter out aws managed keys from policy evaluation

### DIFF
--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
@@ -682,6 +682,4 @@ public interface PacmanSdkConstants {
     String ACCOUNT_ID = "accountid";
     String TAGGING_MANDATORY_TAGS = "tagging.mandatoryTags";
     String POLICY_NAME = "policyName";
-    String KEY_MANAGER = "keymanager";
-    String KEY_MANAGER_TYPE_CUSTOMER = "CUSTOMER";
 }

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -234,10 +234,6 @@ public class PolicyExecutor {
             if (!Strings.isNullOrEmpty(policyParam.get(PacmanSdkConstants.RESOURCE_ID)))
                 filter.put(ESUtils.createKeyword(PacmanSdkConstants.RESOURCE_ID),
                         policyParam.get(PacmanSdkConstants.RESOURCE_ID));
-            /** we dont want to evaluate kms - aws managed keys because they are completely managed by AWS and cannot be changed by user */
-            if ("kms".equalsIgnoreCase(policyParam.get(PacmanSdkConstants.TARGET_TYPE))) {
-                filter.put(ESUtils.createKeyword(PacmanSdkConstants.KEY_MANAGER), PacmanSdkConstants.KEY_MANAGER_TYPE_CUSTOMER);
-            }
 
             if (!filter.isEmpty()) {
                 logger.debug("found filters in rule config, resources will be filtered");


### PR DESCRIPTION
# Description

This reverts the change done in https://github.com/PaladinCloud/CE/pull/1750, since we are fixing this by filtering out the aws managed keys in collector

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
