### PR TITLE
fix:[PLG-352]AccountName population Issue for CQ Collector-GCP

### DIFF
--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/util/Constants.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/util/Constants.java
@@ -37,4 +37,5 @@ public interface Constants {
     String NAME = "name";
 
     String DOC_TYPE = "docType";
+    String ACCOUNT_ID_SQL_QUERY = "SELECT accountName FROM pacmandata.cf_Accounts WHERE accountId =";
 }


### PR DESCRIPTION
# Description

CQ Collector **does not contain AccountName** but AccountID. So we are fetching accountName using RDS from cf_Accounts table by passing accountId. We are using shipper module since it already contains code for RDS connection besides we also need to ship accountName to ES. So shipper module is apt one to make this changes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Made shipper changes and ran the Shipper job for GCP using JobExecutor and checked ES data for accountName. Ensured these data are populated at SAASDEV as well as part of Paladin portal. Also tested negative test case of Azure Data -Shipper to make this RDS Call is only getting executed only for gcp-data-shipper but not for others.

![Shipper_Job_Executor_Loca](https://github.com/PaladinCloud/CE/assets/138756904/ae19bef6-2c64-4d4d-a91c-ec4fe0176ea5)
![OpenSearchResults_AccountName](https://github.com/PaladinCloud/CE/assets/138756904/30eaca1c-a607-4cf2-a032-830c51a55ec7)
![Saasdev_AccName-Verification](https://github.com/PaladinCloud/CE/assets/138756904/2dc1363b-4e58-4857-ad40-8683459aecff)
![Saasdev_Verification_Account_Name](https://github.com/PaladinCloud/CE/assets/138756904/81ff13ab-b837-4b2a-95d7-73c285aec181)
![Azure_Shipper_Job_Negative_Testing](https://github.com/PaladinCloud/CE/assets/138756904/ecb90984-146c-4bc1-b609-5c60bc40f5de)
![AzureShipper_Negative_Test_Case](https://github.com/PaladinCloud/CE/assets/138756904/79924924-f9f6-4444-bced-9330db2dd7a4)




# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
