### PR TITLE
style: added ellipses for values in policy param widget

### DIFF
--- a/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.css
+++ b/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.css
@@ -302,7 +302,7 @@
 }
 
 .params-content .key{
-  flex: 4;
+  flex: 3;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.html
+++ b/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.html
@@ -73,11 +73,11 @@
                         </div>
                         <div class="content-wrapper">
                                 <div class="column-wrapper" *ngFor="let param of paramsArray">
-                                    <div class="col key">
+                                    <div class="col key nowrap-ellipsis">
                                         <span class="param-name nowrap-ellipsis" title="{{param.key}}">{{ param.key }}</span>
                                     </div>
-                                    <div class="col value">
-                                        <span class="param-value nowrap-ellipsis" title="{{param.value}}">{{ param.value == '' ? 'Unknown' : param.value }}</span>
+                                    <div class="col value nowrap-ellipsis">
+                                        <span class="param-value nowrap-ellipsis" title="{{param.value}}">{{ param.value }}</span>
                                     </div>
                                 </div>
                         

--- a/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.ts
+++ b/webapp/src/app/pacman-features/modules/compliance/policy-details/policy-details.component.ts
@@ -214,7 +214,12 @@ export class PolicyDetailsComponent implements OnInit, OnDestroy {
             }
             this.paramsArray = (JSON.parse(response.policyParams).params??[])
             .filter(item => item.isEdit && item.isEdit=="true")
-            .map(item => {return {key: item.displayName || item.key, value: item.value}});
+            .map(item => {              
+              return {
+                key: item.displayName || item.key, 
+                value: item.value || 'unknown'
+              }
+            });
             if(this.paramsArray.length==0){
               this.paramErrorMessage = 'noDataAvailable';
             }else{


### PR DESCRIPTION
# Description
1. Fixed the lengthy values overflowing out of the widget by adding ellipsis to both the key and value.

Before:
![image](https://github.com/PaladinCloud/CE/assets/97596144/90bb37d0-ed44-4c15-92e4-9bdc5e6257ed)
After:
![image](https://github.com/PaladinCloud/CE/assets/97596144/40499236-e037-46d3-851d-ee6465770c51)


Fixes # (issue)
Policy Param Widget in Policy Compliance

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
