### PR TITLE
fix:[PLG-358]API Keys- NULL Handling in Policy execution

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/ConfigureApiRestriction.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/ConfigureApiRestriction.java
@@ -87,11 +87,11 @@ public class ConfigureApiRestriction extends BasePolicy {
             logger.info("hit array size {}",hitsJsonArray.size());
             JsonObject apiKeys = (JsonObject) ((JsonObject) hitsJsonArray.get(0))
                     .get(PacmanRuleConstants.SOURCE);
-            if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull()){
+            if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull()) {
                 validationResult = false;
             }
+            if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {
 
-            if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject() != null && apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size() > 0) {
                 JsonArray apiTargets = apiKeys.get("apiTargetList").getAsJsonArray();
                 for (JsonElement apiTarget : apiTargets) {
                     if (apiTarget.getAsString().equalsIgnoreCase(API_KEY)) {

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/ConfigureApiRestriction.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/ConfigureApiRestriction.java
@@ -87,7 +87,10 @@ public class ConfigureApiRestriction extends BasePolicy {
             logger.info("hit array size {}",hitsJsonArray.size());
             JsonObject apiKeys = (JsonObject) ((JsonObject) hitsJsonArray.get(0))
                     .get(PacmanRuleConstants.SOURCE);
-
+            //handling "restrictions" attribute being NULL
+           // String nullJSonString = "null";
+            if(apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull())
+                return true;
             if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {
 
                 JsonArray apiTargets = apiKeys.get("apiTargetList").getAsJsonArray();

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/ConfigureApiRestriction.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/ConfigureApiRestriction.java
@@ -88,7 +88,7 @@ public class ConfigureApiRestriction extends BasePolicy {
             JsonObject apiKeys = (JsonObject) ((JsonObject) hitsJsonArray.get(0))
                     .get(PacmanRuleConstants.SOURCE);
             //handling "restrictions" attribute being NULL
-           // String nullJSonString = "null";
+         
             if(apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull())
                 return true;
             if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/ConfigureApiRestriction.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/ConfigureApiRestriction.java
@@ -87,12 +87,11 @@ public class ConfigureApiRestriction extends BasePolicy {
             logger.info("hit array size {}",hitsJsonArray.size());
             JsonObject apiKeys = (JsonObject) ((JsonObject) hitsJsonArray.get(0))
                     .get(PacmanRuleConstants.SOURCE);
-            //handling "restrictions" attribute being NULL
-         
-            if(apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull())
-                return true;
-            if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {
+            if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull()){
+                validationResult = false;
+            }
 
+            if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject() != null && apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size() > 0) {
                 JsonArray apiTargets = apiKeys.get("apiTargetList").getAsJsonArray();
                 for (JsonElement apiTarget : apiTargets) {
                     if (apiTarget.getAsString().equalsIgnoreCase(API_KEY)) {

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/ConfigureApiRestriction.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/ConfigureApiRestriction.java
@@ -90,7 +90,8 @@ public class ConfigureApiRestriction extends BasePolicy {
             if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull()) {
                 validationResult = false;
             }
-            if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {
+
+            else if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {
 
                 JsonArray apiTargets = apiKeys.get("apiTargetList").getAsJsonArray();
                 for (JsonElement apiTarget : apiTargets) {

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/EnableAPIApplicationRestriction.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/EnableAPIApplicationRestriction.java
@@ -92,6 +92,10 @@ public class EnableAPIApplicationRestriction extends BasePolicy {
             logger.info("hit array size {}",hitsJsonArray.size());
            JsonObject apiKeys = (JsonObject) ((JsonObject) hitsJsonArray.get(0))
                    .get(PacmanRuleConstants.SOURCE);
+           //handling "restrictions" attribute being NULL
+            String nullJSonString = "null";
+            if(apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull())
+                return true;
 
             if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {
                 logger.info("android Key {} {} {} {} ",apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("androidKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("serverKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("iosKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("browserKeyRestrictions").getAsJsonObject().size());

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/EnableAPIApplicationRestriction.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/EnableAPIApplicationRestriction.java
@@ -93,7 +93,7 @@ public class EnableAPIApplicationRestriction extends BasePolicy {
            JsonObject apiKeys = (JsonObject) ((JsonObject) hitsJsonArray.get(0))
                    .get(PacmanRuleConstants.SOURCE);
            //handling "restrictions" attribute being NULL
-            String nullJSonString = "null";
+
             if(apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull())
                 return true;
 

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/EnableAPIApplicationRestriction.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/EnableAPIApplicationRestriction.java
@@ -92,11 +92,9 @@ public class EnableAPIApplicationRestriction extends BasePolicy {
             logger.info("hit array size {}",hitsJsonArray.size());
            JsonObject apiKeys = (JsonObject) ((JsonObject) hitsJsonArray.get(0))
                    .get(PacmanRuleConstants.SOURCE);
-           //handling "restrictions" attribute being NULL
-
-            if(apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull())
-                return true;
-
+            if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull()) {
+                validationResult = false;
+            }
             if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {
                 logger.info("android Key {} {} {} {} ",apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("androidKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("serverKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("iosKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("browserKeyRestrictions").getAsJsonObject().size());
                 if(apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("androidKeyRestrictions").getAsJsonObject().size()==0 &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("serverKeyRestrictions").getAsJsonObject().size()==0&& apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("iosKeyRestrictions").getAsJsonObject().size()==0&&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("browserKeyRestrictions").getAsJsonObject().size()==0){

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/EnableAPIApplicationRestriction.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/EnableAPIApplicationRestriction.java
@@ -96,7 +96,7 @@ public class EnableAPIApplicationRestriction extends BasePolicy {
                 validationResult = false;
             }
 
-            if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {
+            else if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {
                 logger.info("android Key {} {} {} {} ",apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("androidKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("serverKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("iosKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("browserKeyRestrictions").getAsJsonObject().size());
                 if(apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("androidKeyRestrictions").getAsJsonObject().size()==0 &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("serverKeyRestrictions").getAsJsonObject().size()==0&& apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("iosKeyRestrictions").getAsJsonObject().size()==0&&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("browserKeyRestrictions").getAsJsonObject().size()==0){
                         validationResult=true;

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/EnableAPIApplicationRestriction.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/APIKeys/EnableAPIApplicationRestriction.java
@@ -95,6 +95,7 @@ public class EnableAPIApplicationRestriction extends BasePolicy {
             if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).isJsonNull()) {
                 validationResult = false;
             }
+
             if (apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject()!=null &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().size()>0) {
                 logger.info("android Key {} {} {} {} ",apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("androidKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("serverKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("iosKeyRestrictions").getAsJsonObject().size(),apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("browserKeyRestrictions").getAsJsonObject().size());
                 if(apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("androidKeyRestrictions").getAsJsonObject().size()==0 &&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("serverKeyRestrictions").getAsJsonObject().size()==0&& apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("iosKeyRestrictions").getAsJsonObject().size()==0&&apiKeys.get(PacmanRuleConstants.RESTRICTIONS).getAsJsonObject().get("browserKeyRestrictions").getAsJsonObject().size()==0){


### PR DESCRIPTION
# Description

Enable_API_Key_Application_Restrictions,Enable_API_Key_Restrictions policies got failed due to absence of **"restrictions"** attribute.Handled null case in a such as way if attribute is not present this means there is not restrictions with respect to API Keys. So returning default true in those cases

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
-
# How Has This Been Tested?

Tested by mocking the data at  Junit test file and executing the policy using mocked data. This mocked data is nothing but CQ/Mapper data. **No NULL pointer exception is getting thrown after recent fix**
Recent Test execution
![EnableApiRestrictionPolicyTestJunit](https://github.com/PaladinCloud/CE/assets/138756904/42e5c5ef-4aac-4318-95b8-91668a24d11b)



![image](https://github.com/PaladinCloud/CE/assets/138756904/7ab508ed-5f26-4750-ae96-7a64e4dc5c0f)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
