### PR TITLE
fix:[PLG-357]OpsAlert-NullPointerexception fix for VPC Outbound rule

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/utils/GCPFirewallUtils.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/utils/GCPFirewallUtils.java
@@ -43,6 +43,10 @@ public class GCPFirewallUtils {
                         .equalsIgnoreCase(direction)) {
             return true;
         }
+        boolean isSourceRangeNull = vpcFirewall.getAsJsonObject().get(PacmanRuleConstants.SOURCERANGES).isJsonNull();
+        if (isSourceRangeNull) {
+            return false;
+        }
         JsonArray sourceRanges = vpcFirewall.getAsJsonObject().get(PacmanRuleConstants.SOURCERANGES)
                 .getAsJsonArray();
         JsonArray allow = vpcFirewall.getAsJsonObject().get(PacmanRuleConstants.ALLOW.toLowerCase())


### PR DESCRIPTION
# Description

**VPC_firewall_OuBound_Egress_should_not_be_publicly_accessible** policy execution got failed due to source range being NULL for some of the assets. If the source range is NULL, policy execution should happen as if it wasn’t equal to public access source range(like 0.0.0.0/0).
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

Mocked Mapper generated data where source range is NULL and tested the policy execution using local Junit execution to make sure that NULL pointer exception not getting thrown at local execution
![Uploading VpcFirewallMapperJson.png…]()

![Json_With_SourceRange_null](https://github.com/PaladinCloud/CE/assets/138756904/9b8db54d-a3de-4686-8f31-d512fcde581a)
![Policy_Execution_Junit_TestCase](https://github.com/PaladinCloud/CE/assets/138756904/06c2c77e-ac5f-4663-a63a-2dd2a8c1da6f)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
