### PR TITLE
fix:[CORE-1678] trend graph not showing in standards overview screen …

### DIFF
--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/util/AssetGroupUtil.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/util/AssetGroupUtil.java
@@ -172,7 +172,6 @@ public class AssetGroupUtil {
                 ruleInfo.put(TOTAL, ruleInfoJson.get("assetsScanned").getAsLong());
                 ruleInfo.put(COMPLIANT, ruleInfoJson.get("passed").getAsLong());
                 ruleInfo.put(NON_COMPLIANT, ruleInfoJson.get("failed").getAsLong());
-                ruleInfo.put("contribution_percent", ruleInfoJson.get("contribution_percent").getAsDouble());
                 ruleInfo.put(SEVERITY, ruleInfoJson.get(SEVERITY).getAsString());
                 ruleInfo.put("policyCategory", ruleInfoJson.get("policyCategory").getAsString());
                 ruleInfoList.add(ruleInfo);


### PR DESCRIPTION
…because of changes in /noncompliancepolicy response

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Fixes # (issue)


Recently /noncompliancepolicy api response is updated and attribute 'contribution_percent' is removed. Data shipper is invoking this api for populating assetgroup_stats index and expecting the above attribute because of which exception is thrown. 

Fixed this by removing the attribute from shipper.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
