### PR TITLE
fix:[PLG-371]KmsKeyName issue for Failing Policy

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/encryption/CMKEncryptionRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/encryption/CMKEncryptionRule.java
@@ -84,6 +84,10 @@ public class CMKEncryptionRule extends BasePolicy {
             JsonObject sourceData = (JsonObject) ((JsonObject) hitsJsonArray.get(0))
                     .get(PacmanRuleConstants.SOURCE);
             logger.debug("Data retrieved from ES: {}", sourceData);
+            boolean isKmsKeyNamePresent = sourceData.getAsJsonObject().keySet().contains(PacmanRuleConstants.KMS_KEY_NAME);
+            if(!isKmsKeyNamePresent)
+             return false;
+
             return sourceData.getAsJsonObject().get(PacmanRuleConstants.KMS_KEY_NAME).isJsonNull();
         } else {
             logger.info(PacmanRuleConstants.RESOURCE_DATA_NOT_FOUND);

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/encryption/CMKEncryptionRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/encryption/CMKEncryptionRule.java
@@ -86,7 +86,7 @@ public class CMKEncryptionRule extends BasePolicy {
             logger.debug("Data retrieved from ES: {}", sourceData);
             boolean isKmsKeyNamePresent = sourceData.getAsJsonObject().keySet().contains(PacmanRuleConstants.KMS_KEY_NAME);
             if(!isKmsKeyNamePresent)
-             return false;
+             return true;
 
             return sourceData.getAsJsonObject().get(PacmanRuleConstants.KMS_KEY_NAME).isJsonNull();
         } else {

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/encryption/CMKEncryptionRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/encryption/CMKEncryptionRule.java
@@ -85,8 +85,8 @@ public class CMKEncryptionRule extends BasePolicy {
                     .get(PacmanRuleConstants.SOURCE);
             logger.debug("Data retrieved from ES: {}", sourceData);
             boolean isKmsKeyNamePresent = sourceData.getAsJsonObject().keySet().contains(PacmanRuleConstants.KMS_KEY_NAME);
-            if(!isKmsKeyNamePresent)
-             return true;
+            if (!isKmsKeyNamePresent)
+                return true;
 
             return sourceData.getAsJsonObject().get(PacmanRuleConstants.KMS_KEY_NAME).isJsonNull();
         } else {


### PR DESCRIPTION
# Description
**@policyId:GCP_cloud_sql_encryption_cmks_rule** job failed due to missing attribute of **kmsKeyName** for resourceId
**"central-run-349616:us-east1:test-mysql-with-network"**. So if ksmKeyName is absent we should handle policy as if kmsKeyName is NULL.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Positive Case**: Keep ksmKeyName in Mapper json file in Junit file and check the policy is getting executed successfully


![WithKmsKeyName](https://github.com/PaladinCloud/CE/assets/138756904/2e42f020-c3f2-418e-939d-9761fc573c52)

****Negative Test case:**** Absence of kmsKeyName. It is expected policy should execute without any NULL pointer exception with negative result.


![FailedTestCase_For_Missing_kmsKeyName](https://github.com/PaladinCloud/CE/assets/138756904/4aded0b0-14e2-4efc-8765-3fe29c28b7c0)

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
