### PR TITLE
fix:[PLG-367]Users Atrribute Not found issue for Policy

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/cloudstorage/CloudStorageWithPublicAccessRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/cloudstorage/CloudStorageWithPublicAccessRule.java
@@ -91,20 +91,24 @@ public class CloudStorageWithPublicAccessRule extends BasePolicy {
                     .get(PacmanRuleConstants.SOURCE);
 
             logger.debug("Validating the data item: {}", vmInstanceObject);
-            JsonArray usersArray = vmInstanceObject.getAsJsonObject()
-                    .get(PacmanRuleConstants.USERS).getAsJsonArray();
 
-            if (usersArray.size() > 0) {
-                for (int i = 0; i < usersArray.size(); i++) {
-                    String userDataItem = usersArray
-                            .get(i).getAsString();
-                    if(userDataItem.equalsIgnoreCase(PacmanRuleConstants.ALL_USERS)||userDataItem.equalsIgnoreCase(PacmanRuleConstants.ALL_AUTH_USERS)) {
-                        logger.debug("GCP cloud storage is public");
-                        validationResult = true;
-                        break;
+            boolean usersPresent = vmInstanceObject.getAsJsonObject().keySet().contains(PacmanRuleConstants.USERS);
+            if (usersPresent) {
+                JsonArray usersArray = vmInstanceObject.getAsJsonObject()
+                        .get(PacmanRuleConstants.USERS).getAsJsonArray();
+
+                if (usersArray.size() > 0) {
+                    for (int i = 0; i < usersArray.size(); i++) {
+                        String userDataItem = usersArray
+                                .get(i).getAsString();
+                        if (userDataItem.equalsIgnoreCase(PacmanRuleConstants.ALL_USERS) || userDataItem.equalsIgnoreCase(PacmanRuleConstants.ALL_AUTH_USERS)) {
+                            logger.debug("GCP cloud storage is public");
+                            validationResult = true;
+                            break;
+                        }
                     }
-                }
 
+                }
             } else {
                 logger.info(PacmanRuleConstants.RESOURCE_DATA_NOT_FOUND);
             }

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/cloudstorage/CloudStorageWithPublicAccessRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/cloudstorage/CloudStorageWithPublicAccessRule.java
@@ -91,7 +91,6 @@ public class CloudStorageWithPublicAccessRule extends BasePolicy {
                     .get(PacmanRuleConstants.SOURCE);
 
             logger.debug("Validating the data item: {}", vmInstanceObject);
-
             boolean usersPresent = vmInstanceObject.getAsJsonObject().keySet().contains(PacmanRuleConstants.USERS);
             if (usersPresent) {
                 JsonArray usersArray = vmInstanceObject.getAsJsonObject()


### PR DESCRIPTION
# Description

**@policyId:Cloud_Storage_should_not_be_public** got failed due to **"users"** attribute is not present during policy execution. If users attribute is not present policy should handle as if users list is empty or null.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
-

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

**- Positive Test Case** Users Attribute present in Mock Json(Mapper Generated Json)
![PositiveCase_Users_Present](https://github.com/PaladinCloud/CE/assets/138756904/47490b21-6bc0-464b-9edb-8850f3a836c3)


**Negative Test Case : Users Attribute is not present in Mock Json**
![Negative_TestCase_Users_Not_Present](https://github.com/PaladinCloud/CE/assets/138756904/2ae52e6d-978c-4018-8ead-54efac8840c9)

**Expected** : Policy should execute without Null Pointer exception

Actual: Executed without any issue
![Actual_Execution_Results](https://github.com/PaladinCloud/CE/assets/138756904/4ce17012-e9c6-4ffd-b181-58df1c5fbb6c)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
