### PR TITLE
Fixed tenable collector and policy

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/VMsWithSeverityVulnerabilityRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/VMsWithSeverityVulnerabilityRule.java
@@ -42,6 +42,8 @@ import java.util.*;
 @PacmanPolicy(key = "check-for-vm-vulnerabilities-scanned-by-tenable", desc = "checks for VMs scanned by tenable,and report if vulnerability criteria met", severity = PacmanSdkConstants.SEV_HIGH, category = PacmanSdkConstants.GOVERNANCE)
 public class VMsWithSeverityVulnerabilityRule extends BasePolicy {
 
+    private final String DESCRIPTION_JSON_FIELD = "description";
+    private final String SOLUTION_JSON_FIELD = "solution";
     private static final Logger logger = LoggerFactory.getLogger(VMsWithSeverityVulnerabilityRule.class);
 
     /**
@@ -61,7 +63,7 @@ public class VMsWithSeverityVulnerabilityRule extends BasePolicy {
      */
     @Override
     public PolicyResult execute(Map<String, String> ruleParam, Map<String, String> resourceAttributes) {
-        logger.debug("VMsWithSeverityVulnerabilityRule execution started .............");
+        logger.debug("Policy started");
         MDC.put("executionId", ruleParam.get("executionId")); // this is the logback Mapped Diagnostic Contex
         MDC.put("ruleId", ruleParam.get(PacmanSdkConstants.POLICY_ID)); // this is the logback Mapped Diagnostic Contex
 
@@ -92,7 +94,7 @@ public class VMsWithSeverityVulnerabilityRule extends BasePolicy {
                 JsonObject pluginDetails = firstVulnerability.get("plugin").getAsJsonObject();
 
                 Annotation annotation = Annotation.buildAnnotation(ruleParam, Annotation.Type.ISSUE);
-                annotation.put(PacmanSdkConstants.DESCRIPTION, pluginDetails.get("description").getAsString());
+                annotation.put(PacmanSdkConstants.DESCRIPTION, pluginDetails.get(DESCRIPTION_JSON_FIELD).getAsString());
                 annotation.put(PacmanRuleConstants.SEVERITY, severity);
                 annotation.put(PacmanRuleConstants.CATEGORY, category);
                 annotation.put("issueDetails", Arrays.asList(issueDetails).toString());
@@ -104,7 +106,7 @@ public class VMsWithSeverityVulnerabilityRule extends BasePolicy {
             }
         }
 
-        logger.debug("========VMsWithSeverityVulnerabilityRule ended=========");
+        logger.debug("Policy ended");
 
         return new PolicyResult(PacmanSdkConstants.STATUS_SUCCESS, PacmanRuleConstants.SUCCESS_MESSAGE);
     }
@@ -143,6 +145,10 @@ public class VMsWithSeverityVulnerabilityRule extends BasePolicy {
         String moreInfo = "";
         for (JsonObject vulnerability : vulnerabilityInfoList) {
             JsonObject pluginDetails = vulnerability.get("plugin").getAsJsonObject();
+            if (!pluginDetails.has("see_also") || pluginDetails.get("see_also").isJsonNull()){
+                continue;
+            }
+
             JsonArray seeAlsoList = pluginDetails.get("see_also").getAsJsonArray();
             for (JsonElement elem : seeAlsoList) {
                 moreInfo = moreInfo.concat(elem.getAsString() + " ");
@@ -152,17 +158,23 @@ public class VMsWithSeverityVulnerabilityRule extends BasePolicy {
         issueDetails.put(PacmanRuleConstants.TENABLE_MORE_INFO, moreInfo);
     }
 
-    private Map<String, Object> buildVMIssueDetails(JsonObject elem) {
-        JsonObject pluginDetails = elem.get("plugin").getAsJsonObject();
-        JsonObject assetDetails = elem.get("asset").getAsJsonObject();
+    private Map<String, Object> buildVMIssueDetails(JsonObject vulnerability) {
+        JsonObject pluginDetails = vulnerability.get("plugin").getAsJsonObject();
+        JsonObject assetDetails = vulnerability.get("asset").getAsJsonObject();
 
-        Map<String, Object> issue = new HashMap<>();
-        issue.putIfAbsent(PacmanRuleConstants.VIOLATION_REASON, formatString(pluginDetails.get("description")));
-        issue.putIfAbsent(PacmanRuleConstants.SEVERITY, elem.get(PacmanRuleConstants.SEVERITY).getAsString());
-        issue.putIfAbsent(PacmanRuleConstants.TENABLE_SOLUTION, formatString(pluginDetails.get("solution")));
-        issue.putIfAbsent(PacmanRuleConstants.HOST_NAME, assetDetails.get("instanceId"));
+        Map<String, Object> issueDetails = new HashMap<>();
+        if (pluginDetails.has(DESCRIPTION_JSON_FIELD)){
+            issueDetails.put(PacmanRuleConstants.VIOLATION_REASON, formatString(pluginDetails.get(DESCRIPTION_JSON_FIELD)));
+        }
 
-        return issue;
+        if (pluginDetails.has(SOLUTION_JSON_FIELD)){
+            issueDetails.put(PacmanRuleConstants.TENABLE_SOLUTION, formatString(pluginDetails.get(SOLUTION_JSON_FIELD)));
+        }
+
+        issueDetails.put(PacmanRuleConstants.SEVERITY, vulnerability.get(PacmanRuleConstants.SEVERITY).getAsString());
+        issueDetails.put(PacmanRuleConstants.HOST_NAME, assetDetails.get("instanceId"));
+
+        return issueDetails;
     }
 
     private String formatString(JsonElement element) {

--- a/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/Constants.java
+++ b/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/Constants.java
@@ -16,10 +16,6 @@
 package com.tmobile.cso.pacman.tenable;
 
 public class Constants {
-
-    // TODO: Set to true to get detailed debug logs
-    public static final boolean IS_DEBUG_MODE = true;
-
     public static final String FAILED = "failed";
     public static final String ERROR = "error";
     public static final String EXCEPTION = "exception";

--- a/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/Main.java
+++ b/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/Main.java
@@ -72,7 +72,7 @@ public class Main {
                 log.info("Job executed successfully");
             }
         } else {
-            log.warn("Job hint is not supplied!");
+            log.warn("Job hint is not supplied");
         }
     }
 

--- a/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/jobs/TenableVMVulnerabilityDataImporter.java
+++ b/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/jobs/TenableVMVulnerabilityDataImporter.java
@@ -48,7 +48,7 @@ public class TenableVMVulnerabilityDataImporter extends TenableDataImporter {
     private static final int ASSETS_EXPORT_CHUNK_SIZE = 1000;
     private static final int VULNERABILITY_EXPORT_CHUNK_SIZE = 200;
     private static final String EXPORT_STATUS_MESSAGE_TEMPLATE = "Export Status: %s. Waiting %d more seconds ...";
-    private static final String INTERRUPTED_MESSAGE_TEMPLATE = "Interrupted! {}";
+    private static final String INTERRUPTED_MESSAGE_TEMPLATE = "Interrupted {}";
     private static final List<Map<String, String>> errorList = new ArrayList<>();
     private static final Map<UUID, String> assetMap = new HashMap<>();
 

--- a/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/jobs/TenableVMVulnerabilityDataImporter.java
+++ b/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/jobs/TenableVMVulnerabilityDataImporter.java
@@ -45,8 +45,9 @@ public class TenableVMVulnerabilityDataImporter extends TenableDataImporter {
     private static final String TENABLE_VM_ASSET = "tenable-vm-asset";
     private static final String EXPORT_UUID = "export_uuid";
     private static final int EXPORT_CHECK_RETRY_PERIOD = 120;
-    private static final int EXPORT_CHUNK_SIZE = 1000;
-    private static final String EXPORT_STATUS_MESSAGE_TEMPLATE = "Export Status: %s. Waiting for %d more seconds to complete ...";
+    private static final int ASSETS_EXPORT_CHUNK_SIZE = 1000;
+    private static final int VULNERABILITY_EXPORT_CHUNK_SIZE = 200;
+    private static final String EXPORT_STATUS_MESSAGE_TEMPLATE = "Export Status: %s. Waiting %d more seconds ...";
     private static final String INTERRUPTED_MESSAGE_TEMPLATE = "Interrupted! {}";
     private static final List<Map<String, String>> errorList = new ArrayList<>();
     private static final Map<UUID, String> assetMap = new HashMap<>();
@@ -124,7 +125,7 @@ public class TenableVMVulnerabilityDataImporter extends TenableDataImporter {
         }
 
         log.info("Asset Export Completed");
-        log.info("Chunks Produced (each chunk up to {} items): {}", EXPORT_CHUNK_SIZE, exportStatus.getChunkIds().size());
+        log.info("Chunks Produced (each chunk up to {} items): {}", ASSETS_EXPORT_CHUNK_SIZE, exportStatus.getChunkIds().size());
         List<Map<String, Object>> assets = exportAssets(assetExportIdentifier, exportStatus);
         log.info("Total Assets Exported: {}", assets.size());
         return assets;
@@ -160,7 +161,7 @@ public class TenableVMVulnerabilityDataImporter extends TenableDataImporter {
         }
 
         log.info("Vulnerability Export Completed");
-        log.info("Chunks Produced (each chunk up to {} items): {}", EXPORT_CHUNK_SIZE, exportStatus.getChunkIds().size());
+        log.info("Chunks Produced: {}", exportStatus.getChunkIds().size());
         List<Map<String, Object>> vulnerabilities = exportVulnerabilities(vulnerabilityExportIdentifier, exportStatus);
         log.info("Total Vulnerabilities Exported: {}", vulnerabilities.size());
         return vulnerabilities;
@@ -183,7 +184,7 @@ public class TenableVMVulnerabilityDataImporter extends TenableDataImporter {
                     if (!parsedResponse.isEmpty()) {
                         List<Map<String, Object>> filteredResponse = parsedResponse
                                 .stream()
-                                .filter(asset -> ((List<String>) asset.get("system_types")).contains("aws-ec2-instance"))
+                                .filter(asset -> asset.get("aws_ec2_instance_id") != null)
                                 .collect(Collectors.toList());
                         assetMap.putAll(
                                 filteredResponse
@@ -264,26 +265,18 @@ public class TenableVMVulnerabilityDataImporter extends TenableDataImporter {
     private UUID triggerAssetExport() throws TenableDataImportException {
         // TODO: Per Tenable, need to limit asset data we collect to new data appeared since last scan.
         JSONObject jsonObject = new JSONObject();
-        jsonObject.put("chunk_size", EXPORT_CHUNK_SIZE);
+        jsonObject.put("chunk_size", ASSETS_EXPORT_CHUNK_SIZE);
         jsonObject.put("include_unlicensed", true);
         String requestBody = jsonObject.toString();
-        if (Constants.IS_DEBUG_MODE) {
-            log.debug("Asset Export Request Body -> {}", requestBody);
-        }
+        log.info("Asset Export Request Body -> {}", requestBody);
 
         Map<String, String> input = getBaseTenableInput();
 
         try {
             String assetExportApiPath = apiMap.get("assetsExportTrigger");
             String assetExportApiUrl = getTenableApiUrl(assetExportApiPath);
-            if (Constants.IS_DEBUG_MODE) {
-                log.debug("Asset Export Url -> {}", assetExportApiUrl);
-            }
-
             String response = HttpUtil.post(assetExportApiUrl, requestBody, input);
-            if (Constants.IS_DEBUG_MODE) {
-                log.info("Asset Export Response -> {}", response);
-            }
+            log.info("Asset Export Response -> {}", response);
 
             Map<String, Object> parsedResponse = ((Map<String, Object>) Util.getJsonBuilder().fromJson(response, Map.class));
             if (parsedResponse != null && parsedResponse.get(EXPORT_UUID) != null) {
@@ -318,9 +311,7 @@ public class TenableVMVulnerabilityDataImporter extends TenableDataImporter {
         JSONObject filters = new JSONObject();
 
         // TODO we can monitor and tune this
-        jsonObject.put(
-                "num_assets",
-                assetMap.keySet().size() < EXPORT_CHUNK_SIZE ? assetMap.keySet().size() : EXPORT_CHUNK_SIZE);
+        jsonObject.put("num_assets", VULNERABILITY_EXPORT_CHUNK_SIZE);
         filters.put("severity", Arrays.asList("low", "medium", "high", "critical"));
 
         // TODO now considering 1 yrs old data we have to make it configurable
@@ -328,8 +319,7 @@ public class TenableVMVulnerabilityDataImporter extends TenableDataImporter {
         jsonObject.put("filters", filters);
         jsonObject.put("include_unlicensed", true);
         String requestBody = jsonObject.toString();
-        if (Constants.IS_DEBUG_MODE)
-            log.debug("Vulnerability Export Request Body -> {}", requestBody);
+        log.info("Vulnerability Export Request Body -> {}", requestBody);
 
         Map<String, String> input = getBaseTenableInput();
 

--- a/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/util/ConfigUtil.java
+++ b/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/util/ConfigUtil.java
@@ -79,7 +79,7 @@ public class ConfigUtil {
             throw new TenableDataImportException("No config properties fetched from " + configUrl);
         }
 
-        LOGGER.info("Config are fetched from {}", configUrl);
+        LOGGER.debug("Config are fetched from {}", configUrl);
         return properties;
     }
 }

--- a/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/util/ElasticSearchManager.java
+++ b/jobs/pacman-tenable-enricher/src/main/java/com/tmobile/cso/pacman/tenable/util/ElasticSearchManager.java
@@ -121,7 +121,7 @@ public class ElasticSearchManager {
     public static void uploadData(String index, String type, List<Map<String, Object>> docs, String idKey) {
         String actionTemplate = "{ \"index\" : { \"_index\" : \"%s\", \"_id\" : \"%s\"} }%n";
 
-        LOGGER.info("*********UPLOADING*** {}", type);
+        LOGGER.info("Uploading type \"{}\"", type);
         if (null != docs && !docs.isEmpty()) {
             StringBuilder bulkRequest = new StringBuilder();
             int i = 0;


### PR DESCRIPTION
# Description

Changed filtering for assets - asset must have "aws_ec2_instance_id" != null.
Number of assets per vulnerabilities chunk made fixed: 200
Added some checks to avoid null exceptions in policy
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested in SaaSQA:
![image](https://github.com/PaladinCloud/CE/assets/133698330/ee3554a3-59e0-4025-b09d-347f1584ed24)
