### PR TITLE
fix:[PLG-369]UsersNull fix for "delete_unused_vm_disk" Policy Engine

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/Disks/DeleteUnusedVMDisk.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/Disks/DeleteUnusedVMDisk.java
@@ -90,13 +90,15 @@ public class DeleteUnusedVMDisk extends BasePolicy {
                     .get(PacmanRuleConstants.SOURCE);
 
             logger.debug("Validating the data item: {}", disksObject);
-
-            JsonArray users=disksObject.get(PacmanRuleConstants.USERS).getAsJsonArray();
-
-            if(users.isEmpty()){
-                validationResult=true;
+            boolean isUsersObjectNull = disksObject.get(PacmanRuleConstants.USERS).isJsonNull();
+            if (isUsersObjectNull)
+                validationResult = true;
+            else {
+                JsonArray users = disksObject.get(PacmanRuleConstants.USERS).getAsJsonArray();
+                if (users.isEmpty()) {
+                    validationResult = true;
+                }
             }
-
         } else {
             logger.info(PacmanRuleConstants.RESOURCE_DATA_NOT_FOUND);
         }


### PR DESCRIPTION
# Description
@PolicyID **"delete_unused_vm_disk"** got failed due to "users" attribute being NULL for resource ID "1316521205842241414". Policy should handle this scenario as if users are empty which is already handled by policy engine.


Fixes # (issue)
We are changing the policy engine to execute this scenario as if users are empty.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
**Mock the Test file using CQ/Mapper Data**

![MockData_Users_Null](https://github.com/PaladinCloud/CE/assets/138756904/19ecfa7a-309b-4792-93c7-438368389f80)

**Negative Test scenario:**
Mock the test data using  **Mapper/CQ** generated data where users attribute is just NULL and try to execute the policy to make sure that NULL pointer exception is not being thrown.
Expected behaviour
1) Null pointer exception should not get thrown
2) Policy should throw violation because because users are not attached

![Violation_Results_Negative_Test_Case_Users_Null](https://github.com/PaladinCloud/CE/assets/138756904/966e4cdf-fec6-406d-8a81-7f7c8aaa8955)




****Positive Test Case**

Mock the test data using  **Mapper/CQ** generated data where users attribute is just NOT NULL and try to execute the policy to make sure that NULL pointer exception is not being thrown.
Expected behaviour
1) Null pointer exception should not get thrown
2) Policy should execute without throwing violation because because users are attached



![Positive_Test_Case_Users_Present](https://github.com/PaladinCloud/CE/assets/138756904/ba8daaf8-d581-4b9a-a1e7-73ad5d592ebf)




Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
