### PR TITLE
fix:[PLG-366]NatIp Null Pointer fix for PolicyExecution

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/vminstance/VMInstanceWithPublicAccess.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/vminstance/VMInstanceWithPublicAccess.java
@@ -153,13 +153,17 @@ public class VMInstanceWithPublicAccess extends BasePolicy {
         for (int j = 0; j < accessConfigJsonArray.size(); j++) {
             JsonObject accessConfigDataItem = ((JsonObject) accessConfigJsonArray
                     .get(j));
-
-            String natIp = accessConfigDataItem.getAsJsonObject()
-                    .get(PacmanRuleConstants.GCP_NAT_IP).getAsString();
-
-            if (!StringUtils.isNullOrEmpty(natIp)) {
-                validationResult = false;
-                break;
+            boolean isNatIpNull = accessConfigDataItem.getAsJsonObject()
+                    .get(PacmanRuleConstants.GCP_NAT_IP).isJsonNull();
+            if (isNatIpNull) {
+                validationResult = true;
+            } else {
+                String natIp = accessConfigDataItem.getAsJsonObject()
+                        .get(PacmanRuleConstants.GCP_NAT_IP).getAsString();
+                if (!StringUtils.isNullOrEmpty(natIp)) {
+                    validationResult = false;
+                    break;
+                }
             }
         }
         return validationResult;


### PR DESCRIPTION
# Description

@PolicyID **GCP_Virtual_Machine_public_access_version** got failed to execute to incorrect mapper attribute as well as null pointer exception at policy side

Fixes # (issue)

Mapper side also attribute fix addressed as part of https://github.com/PaladinCloud/Plugins/pull/85/files.
Besides this also needs to be addressed at Policy side as well which exactly getting done as part of this PR

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

**Mock the Junit Test case with CQ/Mapper data**

![Latest_Mapper_Cq_with_NatIP](https://github.com/PaladinCloud/CE/assets/138756904/563dcc20-34fa-40f3-ad60-0966a65aa652)

**Test Case with NatIp being NULL**
![Mapper_Cq_Mock_data_NatIp_NULL](https://github.com/PaladinCloud/CE/assets/138756904/ef099a6f-4717-4655-b6e6-77c24b669106)

Execution results

![VmInstance_PulicAccess_Test](https://github.com/PaladinCloud/CE/assets/138756904/0383eb09-d5a2-4ca4-83dc-c28296784eb0)

Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
