### PR TITLE
fix: [CORE-1303] Using regional endpoints for STS

### DIFF
--- a/installer/resources/batch/job.py
+++ b/installer/resources/batch/job.py
@@ -35,9 +35,13 @@ class SubmitAndRuleEngineJobDefinition(BatchJobDefinitionResource):
             {'name': "HEIMDALL_URI", 'value': ESDomain.get_http_url_with_port()},
             {'name': "PACMAN_API_URI", 'value': ApplicationLoadBalancer.get_api_base_url()},
             {'name': "CONFIG_CREDENTIALS", 'value': "dXNlcjpwYWNtYW4="},
-            {'name': "CONFIG_SERVICE_URL", 'value': ApplicationLoadBalancer.get_http_url() + "/api/config/rule,batch/prd/latest"},
-            {'name': "AUTH_API_URL",'value': "https://"+ Settings.COGNITO_DOMAIN + ".auth." + Settings.AWS_REGION + ".amazoncognito.com"},
-            {'name': "POLICY_DETAILS_URL", 'value': ApplicationLoadBalancer.get_http_url() + "/api/compliance/v1/policy-details-by-uuid?policyUUID="}
+            {'name': "CONFIG_SERVICE_URL",
+             'value': ApplicationLoadBalancer.get_http_url() + "/api/config/rule,batch/prd/latest"},
+            {'name': "AUTH_API_URL",
+             'value': "https://" + Settings.COGNITO_DOMAIN + ".auth." + Settings.AWS_REGION + ".amazoncognito.com"},
+            {'name': "POLICY_DETAILS_URL",
+             'value': ApplicationLoadBalancer.get_http_url() + "/api/compliance/v1/policy-details-by-uuid?policyUUID="},
+            {'name': "AWS_STS_REGIONAL_ENDPOINTS", 'value': "regional"}
         ]
     })
 


### PR DESCRIPTION
# Description

- Regional endpoint credentials are needed for reading the data from non-default regions. Currently, we are using temporary credentials from the global STS endpoint which are by default valid only in default AWS regions. Because of this, we are unable to read any data from non-default AWS regions (e.g. af-south-1).

- Added an env variable to force SDK to use regional STS endpoints. By default regional endpoint tokens are valid across all the regions.

- Also, omitted the errors coming from disabled regions from raising alerts. As they we can ignore them.
- Printing all the remaining errors at the end of the log file for easy access.


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Ran the collector in dev and see that:
   * Collector ran fine
   * Abled to collect the data from af-south-1 which is non default region
   * Able to see the disabled region errors are omitted from the error map in local debugging.

![image](https://github.com/PaladinCloud/CE/assets/72746503/0116d92a-e1d7-4232-aea0-65fea45beda4)
![image](https://github.com/PaladinCloud/CE/assets/72746503/98508253-e853-4e05-807e-49087805f502)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas

# **Other Information**:

List any documentation updates that are needed for the Wiki
