### PR TITLE
fix:[CORE-1679] Updated the cve url for tenable vulnerabilty info

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/VMsWithSeverityVulnerabilityRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/VMsWithSeverityVulnerabilityRule.java
@@ -124,7 +124,7 @@ public class VMsWithSeverityVulnerabilityRule extends BasePolicy {
                 vul.setVulnerabilityUrl("https://cloud.tenable.com/tio/app.html#/vulnerability-management/dashboard/vulnerabilities/by-plugins/vulnerability-details/" + assetId + "/assets-affected");
                 for (JsonElement elem : cveDetails.getAsJsonArray()) {
                     String id = elem.getAsString();
-                    CveDetails cve = new CveDetails(id, "https://www.tenable.com/cve/" + id);
+                    CveDetails cve = new CveDetails(id, PacmanUtils.NIST_VULN_DETAILS_URL + id);
                     cveList.add(cve);
                 }
 


### PR DESCRIPTION
# Description

-Changed the cve url in Vulnerability Information for tenable to nvd.nist.gov. This change is not dependent on anything

Fixes # (issue)
This fixes the  cve url in Vulnerability Information for tenable 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Look at the cve url for Tenable vulnerability on UI before the fix
- [x] Run the Tenable policies after the fix
- [x] verify that the url generated for aws_ec2 issue in ES is nvd.nist.gov
- [x] verify on the UI that the cve url for Tenable vulnerability is nvd.nist.gov

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
