### PR TITLE
fix:set log level to error in scheduler batch job and conf…

### DIFF
--- a/api/pacman-api-config/src/main/resources/application.yml
+++ b/api/pacman-api-config/src/main/resources/application.yml
@@ -26,4 +26,8 @@ server:
   servlet:
     context-path: /api/config
 
+logging:
+  level:
+    root: ERROR
+
  

--- a/jobs/job-scheduler/src/main/resources/bootstrap.yml
+++ b/jobs/job-scheduler/src/main/resources/bootstrap.yml
@@ -23,3 +23,7 @@ spring:
 server:
   servlet:
     context-path: /api/job
+
+logging:
+  level:
+    root: ERROR


### PR DESCRIPTION
# Description

Set log level to error in scheduler batch and config API, as there are printing unnecessary logs that are causing the OPS alerts.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
