### PR TITLE
fix:[PLG-374]NullPointer exception fix

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/cloudstorage/CloudStorageWithPublicAccessRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/gcprules/cloudstorage/CloudStorageWithPublicAccessRule.java
@@ -91,7 +91,8 @@ public class CloudStorageWithPublicAccessRule extends BasePolicy {
                     .get(PacmanRuleConstants.SOURCE);
 
             logger.debug("Validating the data item: {}", vmInstanceObject);
-            boolean usersPresent = vmInstanceObject.getAsJsonObject().keySet().contains(PacmanRuleConstants.USERS);
+            boolean usersPresent = vmInstanceObject.getAsJsonObject().keySet().contains(PacmanRuleConstants.USERS) && !vmInstanceObject.getAsJsonObject()
+                    .get(PacmanRuleConstants.USERS).isJsonNull();
             if (usersPresent) {
                 JsonArray usersArray = vmInstanceObject.getAsJsonObject()
                         .get(PacmanRuleConstants.USERS).getAsJsonArray();


### PR DESCRIPTION
# Description

**@policyId:Cloud_Storage_should_not_be_public failure**  got failed due to users attribute being NULL. Earlier this was failing due to missing attribute. Now though this users attribute present it got failed users being NULL. So handled additional condition to make sure policy does not throw NULL pointer exception at any cost.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Step 1: Mock the **CloudStorageWithPublicAccessRuleTest** Junit Test case file with CQ/Mapper data with **users being NULL****


![Users_Null_Cloud_Storage](https://github.com/PaladinCloud/CE/assets/138756904/869a2ed5-818c-4dcc-a0e3-98b984e71fc1)

Step 2: Execute Junit Test file /Method

![Policy_Execution_Without_Exception](https://github.com/PaladinCloud/CE/assets/138756904/359d54d7-cbb1-4880-88ed-ba5ad19e1ff0)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
