### PR TITLE
feat:[PLG-356] Changing validation URL to /session

### DIFF
--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/TenableAccountServiceImpl.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/TenableAccountServiceImpl.java
@@ -63,7 +63,7 @@ public class TenableAccountServiceImpl extends AbstractAccountServiceImpl implem
     private AccountValidationResponse validateAccountCredentials(CreateAccountRequest accountData) {
         AccountValidationResponse validationResponse = new AccountValidationResponse();
         // Requesting scan that doesn't exist to validate the account data.
-        HttpGet request = new HttpGet(Constants.TENABLE_API_URL + "/scans/0");
+        HttpGet request = new HttpGet(Constants.TENABLE_API_URL + "/session");
         String apiKey = "accessKey=" + accountData.getTenableAccessKey() + ";secretKey=" + accountData.getTenableSecretKey() + ";";
         request.addHeader("X-ApiKeys", apiKey);
         request.addHeader("content-type", "application/json");
@@ -73,13 +73,13 @@ public class TenableAccountServiceImpl extends AbstractAccountServiceImpl implem
             CloseableHttpClient httpClient = HttpClientBuilder.create().build();
             CloseableHttpResponse response = httpClient.execute(request);
 
-            if (response.getEntity() != null && response.getStatusLine().getStatusCode() == 401) {
+            if (response.getStatusLine().getStatusCode() == 200) {
+                validationResponse.setValidationStatus(SUCCESS);
+                validationResponse.setMessage("Tenable account validation passed");
+            } else {
                 // If the response is 401, then the account data is not valid.
                 validationResponse.setValidationStatus(FAILURE);
                 validationResponse.setMessage("Tenable API keys validation failed.");
-            } else {
-                validationResponse.setValidationStatus(SUCCESS);
-                validationResponse.setMessage("Tenable account validation passed");
             }
         } catch (IOException e) {
             LOGGER.error("Failed to validate the tenable account ", e.getMessage());


### PR DESCRIPTION
# Description

Tenable provided API which suits for checking API keys without hacks.
`/session`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Successful validation:
<img width="504" alt="Screenshot 2023-11-16 at 2 34 34 PM" src="https://github.com/PaladinCloud/CE/assets/133698330/b3371247-8141-4f8a-bfe0-e2ccfc8fd5d1">

Failed validation:
<img width="509" alt="Screenshot 2023-11-16 at 2 34 58 PM" src="https://github.com/PaladinCloud/CE/assets/133698330/168017e6-b179-48ee-9a52-5c6c0d5128bc">
