### PR TITLE
fix:[CORE-1647] Updated aliasQuery in cf_AssetGroupDetails

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -3086,11 +3086,13 @@ update pac_v2_ui_options set optionURL="/admin/accounts/filter/attribute?attribu
 
 /* updating targetName and displayName for azure kubernetes */
 DELETE IGNORE FROM cf_Target WHERE targetName='kubernetes';
+update cf_AssetGroupDetails set aliasQuery=replace(aliasQuery,'\"index\":\"azure_kubernetes\"','\"index\":\"azure_aks\"');
 UPDATE cf_AssetGroupTargetDetails SET targetType='aks' WHERE targetType='kubernetes';
 UPDATE cf_AssetGroupCriteriaDetails SET attributeValue='aks' WHERE attributeValue='kubernetes';
 
 /* updating targetName and displayName for gcp gkecluster */
 DELETE IGNORE FROM cf_Target WHERE targetName='gkecluster';
+update cf_AssetGroupDetails set aliasQuery=replace(aliasQuery,'\"index\":\"gcp_gkecluster\"','\"index\":\"gcp_gke\"');
 UPDATE cf_AssetGroupTargetDetails SET targetType='gke' WHERE targetType='gkecluster';
 UPDATE cf_AssetGroupCriteriaDetails SET attributeValue='gke' WHERE attributeValue='gkecluster';
 


### PR DESCRIPTION
# Description

As we changing the target nam, we need to make changes to the aliasQuery in cf_AssetGroupDetails table.
- renamed indices in cf_AssetGroupDetails.aliasQuery for azure_kubernetes and gcp_gkecluster

Fixes # (issue)
Fixes the index name in cf_AssetGroupDetails.aliasQuery

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Add the targetTypes azure_kubernetes and gcp_gkecluster as criteria in an asset group
- [ ] After the query has run and after reindexing, verify the assets are present in the asset group

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
