### PR TITLE
feat:[PLG-362] Deletion of a plugin should be self contained

### DIFF
--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AbstractAccountServiceImpl.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AbstractAccountServiceImpl.java
@@ -58,7 +58,6 @@ public abstract class AbstractAccountServiceImpl implements AccountsService{
     protected AssetGroupService assetGroupService;
     @Autowired
     private UserPreferencesService userPreferencesService;
-    ;
     @Value("${secret.manager.path}")
     private String secretManagerPrefix;
     public static final String DATE_FORMAT = "MM/dd/yyyy HH:mm:ss";
@@ -297,9 +296,9 @@ public abstract class AbstractAccountServiceImpl implements AccountsService{
             logger.info("AssetGroup deletion status is {} for {}", deleteAssetGroupStatus, pluginName);
             Integer totalUsers = userPreferencesService.updateDefaultAssetGroup(pluginName);
             logger.info("Total users have been updated with the default asset group. The new count is: {}", totalUsers);
-            assetGroupService.updatePluginDataInAssetGroup(pluginName, true);
+            assetGroupService.removePluginTypeFromAllSources(pluginName);
         } catch (Exception e) {
-            logger.error("Unable to make changes to required asset groups for {}", pluginName, e);
+            logger.error("Unable to disable asset groups for {}", pluginName, e);
         }
     }
 }

--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupService.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupService.java
@@ -110,8 +110,7 @@ public interface AssetGroupService {
 	public List<String> getFilterKeyValues(String key) throws  PacManException;
 
 	public List<Map<String,Object>> getCloudTypeObject() throws Exception;
-
-	public String updateAssetGroupStatus (final String assetGroupName, final boolean status, final String userId) throws PacManException;
 	void createOrUpdatePluginAssetGroup(String pluginType, String displayName);
-	List<String> fetchIndices(String pluginName);
+	boolean deleteAssetGroupByGroupName(String groupName);
+	void updatePluginDataInAssetGroup(String pluginName, boolean isRemoved);
 }

--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupService.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupService.java
@@ -113,4 +113,5 @@ public interface AssetGroupService {
 
 	public String updateAssetGroupStatus (final String assetGroupName, final boolean status, final String userId) throws PacManException;
 	void createOrUpdatePluginAssetGroup(String pluginType, String displayName);
+	List<String> fetchIndices(String pluginName);
 }

--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupService.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupService.java
@@ -112,5 +112,8 @@ public interface AssetGroupService {
 	public List<Map<String,Object>> getCloudTypeObject() throws Exception;
 	void createOrUpdatePluginAssetGroup(String pluginType, String displayName);
 	boolean deleteAssetGroupByGroupName(String groupName);
-	void updatePluginDataInAssetGroup(String pluginName, boolean isRemoved);
+
+	void addPluginTypeToAllSources(String pluginName);
+
+	void removePluginTypeFromAllSources(String pluginName);
 }

--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupServiceImpl.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupServiceImpl.java
@@ -15,6 +15,63 @@
  ******************************************************************************/
 package com.tmobile.pacman.api.admin.repository.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.tmobile.pacman.api.admin.common.AdminConstants;
+import com.tmobile.pacman.api.admin.domain.AssetGroupView;
+import com.tmobile.pacman.api.admin.domain.AttributeDetails;
+import com.tmobile.pacman.api.admin.domain.CreateAssetGroup;
+import com.tmobile.pacman.api.admin.domain.CreateUpdateAssetGroupDetails;
+import com.tmobile.pacman.api.admin.domain.DeleteAssetGroupRequest;
+import com.tmobile.pacman.api.admin.domain.TargetTypesDetails;
+import com.tmobile.pacman.api.admin.domain.UpdateAssetGroupDetails;
+import com.tmobile.pacman.api.admin.exceptions.PacManException;
+import com.tmobile.pacman.api.admin.repository.AssetGroupCriteriaDetailsRepository;
+import com.tmobile.pacman.api.admin.repository.AssetGroupRepository;
+import com.tmobile.pacman.api.admin.repository.AssetGroupTargetDetailsRepository;
+import com.tmobile.pacman.api.admin.repository.TargetTypesRepository;
+import com.tmobile.pacman.api.admin.repository.model.AssetGroupCriteriaDetails;
+import com.tmobile.pacman.api.admin.repository.model.AssetGroupDetails;
+import com.tmobile.pacman.api.admin.repository.model.AssetGroupTargetDetails;
+import com.tmobile.pacman.api.admin.service.CommonService;
+import com.tmobile.pacman.api.admin.util.AdminUtils;
+import com.tmobile.pacman.api.commons.Constants;
+import com.tmobile.pacman.api.commons.exception.DataException;
+import com.tmobile.pacman.api.commons.exception.ServiceException;
+import com.tmobile.pacman.api.commons.repo.ElasticSearchRepository;
+import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.client.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.configurationprocessor.json.JSONArray;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import static com.tmobile.pacman.api.admin.common.AdminConstants.ASSET_GROUP_ALIAS_DELETION_FAILED;
 import static com.tmobile.pacman.api.admin.common.AdminConstants.ASSET_GROUP_CREATION_SUCCESS;
 import static com.tmobile.pacman.api.admin.common.AdminConstants.ASSET_GROUP_DELETE_FAILED;
@@ -24,50 +81,7 @@ import static com.tmobile.pacman.api.admin.common.AdminConstants.ASSET_GROUP_UPD
 import static com.tmobile.pacman.api.admin.common.AdminConstants.DATE_FORMAT;
 import static com.tmobile.pacman.api.admin.common.AdminConstants.ES_ALIASES_PATH;
 import static com.tmobile.pacman.api.admin.common.AdminConstants.UNEXPECTED_ERROR_OCCURRED;
-import static com.tmobile.pacman.api.commons.Constants.ALL_SOURCES_ASSET_GROUP;
-
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-
-import com.google.gson.*;
-import com.tmobile.pacman.api.commons.exception.DataException;
-import com.tmobile.pacman.api.commons.exception.ServiceException;
-import org.apache.commons.lang.StringUtils;
-
-import com.tmobile.pacman.api.admin.common.AdminConstants;
-import com.tmobile.pacman.api.admin.domain.*;
-import com.tmobile.pacman.api.admin.repository.model.AssetGroupCriteriaDetails;
-import com.tmobile.pacman.api.commons.Constants;
-import com.tmobile.pacman.api.commons.repo.ElasticSearchRepository;
-import org.apache.http.util.EntityUtils;
-import org.elasticsearch.client.Response;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.boot.configurationprocessor.json.JSONArray;
-import org.springframework.boot.configurationprocessor.json.JSONObject;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.tmobile.pacman.api.admin.exceptions.PacManException;
-import com.tmobile.pacman.api.admin.repository.AssetGroupRepository;
-import com.tmobile.pacman.api.admin.repository.AssetGroupTargetDetailsRepository;
-import com.tmobile.pacman.api.admin.repository.AssetGroupCriteriaDetailsRepository;
-import com.tmobile.pacman.api.admin.repository.TargetTypesRepository;
-import com.tmobile.pacman.api.admin.repository.model.AssetGroupDetails;
-import com.tmobile.pacman.api.admin.repository.model.AssetGroupTargetDetails;
-import com.tmobile.pacman.api.admin.service.CommonService;
-import com.tmobile.pacman.api.admin.util.AdminUtils;
-import org.springframework.util.CollectionUtils;
+import static com.tmobile.pacman.api.commons.Constants.GROUP_NAME_FOR_ALL_SOURCES_ASSET_GROUP;
 
 /**
  * AssetGroup Service Implementations
@@ -80,6 +94,8 @@ public class AssetGroupServiceImpl implements AssetGroupService {
 	private static final String ALIASES = "/_aliases";
 	private static  final  String BUCKETS="buckets";
 	private  static  final  String KEY="key";
+	private static final String ALIASES_ACTION_TEMPLATE = "{\"actions\":[%s]}";
+	private static final String ACTION_TEMPLATE = "{\"%s\":{\"index\":\"%s\",\"alias\":\"%s\"}}";
 
 	@Autowired
 	private AssetGroupRepository assetGroupRepository;
@@ -813,7 +829,7 @@ public class AssetGroupServiceImpl implements AssetGroupService {
 			log.info("Asset group created for pluginType : {}", pluginType);
 			assetGroupRepository.save(assetGroupDetails);
 			// Trying to re-add indices of plugin type to asset group
-			updatePluginDataInAssetGroup(pluginType, false);
+			addPluginTypeToAllSources(pluginType);
 		} catch (Exception e) {
 			log.error("Asset group creation for {} failed", pluginType, e);
 		}
@@ -842,39 +858,49 @@ public class AssetGroupServiceImpl implements AssetGroupService {
 		try {
 			AssetGroupDetails assetGroupInDB = assetGroupRepository.findByGroupName(groupName);
 			if (assetGroupInDB == null) {
-				log.error("Asset group not found with group name as {}", groupName);
+				log.error("Asset group {} not found", groupName);
 				return false;
 			}
 			assetGroupRepository.delete(assetGroupInDB);
-			log.info("asset group with group name {} deleted successfully", groupName);
+			log.info("Asset group {} deleted", groupName);
 			return true;
 		} catch (Exception e) {
-			log.error("Unable to delete asset group with group name as {}", groupName, e);
+			log.error("Unable to delete asset group {}", groupName, e);
 			return false;
 		}
 	}
 
 	@Override
-	public void updatePluginDataInAssetGroup(String pluginName, boolean isRemoved) {
+	public void addPluginTypeToAllSources(String pluginName) {
 		try {
-			StringBuilder requestBody = new StringBuilder("{\"actions\":[");
-			if (isRemoved) {
-				requestBody.append("{\"remove\":{\"index\":\"").append(pluginName)
-						.append("_*\",\"alias\":\"").append(ALL_SOURCES_ASSET_GROUP).append("\"}},");
-			} else {
-				requestBody.append("{\"add\":{\"index\":\"").append(pluginName)
-						.append("_*\",\"alias\":\"").append(ALL_SOURCES_ASSET_GROUP).append("\"}},");
-			}
-			requestBody.deleteCharAt(requestBody.length() - 1);
-			requestBody.append("]}");
-			Response response = commonService.invokeAPI("POST", ES_ALIASES_PATH, requestBody.toString());
+			String actionTemplate = String.format(ACTION_TEMPLATE, "add", pluginName + "_*",
+					GROUP_NAME_FOR_ALL_SOURCES_ASSET_GROUP);
+			String aliasQuery = String.format(ALIASES_ACTION_TEMPLATE, actionTemplate);
+			Response response = commonService.invokeAPI("POST", ES_ALIASES_PATH, aliasQuery);
 			if (response == null || response.getStatusLine().getStatusCode() != 200) {
-				log.error("Unable to remove or update indices for asset group {} with response {}",
-						ALL_SOURCES_ASSET_GROUP, response);
+				log.error("Unable to add indices for asset group {} with response {}",
+						GROUP_NAME_FOR_ALL_SOURCES_ASSET_GROUP, response);
 			}
-			log.info("Indices updated for plugin successfully.");
+			log.info("Indices added for {}", pluginName);
 		} catch (Exception e) {
-			log.error("Unable to remove or update indices for Plugin : {} From AssetGroup", pluginName, e);
+			log.error("Unable to add indices for {}", pluginName, e);
+		}
+	}
+
+	@Override
+	public void removePluginTypeFromAllSources(String pluginName) {
+		try {
+			String actionTemplate = String.format(ACTION_TEMPLATE, "remove", pluginName + "_*",
+					GROUP_NAME_FOR_ALL_SOURCES_ASSET_GROUP);
+			String aliasQuery = String.format(ALIASES_ACTION_TEMPLATE, actionTemplate);
+			Response response = commonService.invokeAPI("POST", ES_ALIASES_PATH, aliasQuery);
+			if (response == null || response.getStatusLine().getStatusCode() != 200) {
+				log.error("Unable to remove indices for asset group {} with response {}",
+						GROUP_NAME_FOR_ALL_SOURCES_ASSET_GROUP, response);
+			}
+			log.info("Indices removed for {}", pluginName);
+		} catch (Exception e) {
+			log.error("Unable to remove indices for {}", pluginName, e);
 		}
 	}
 }

--- a/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
+++ b/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
@@ -573,4 +573,5 @@ public interface Constants {
     } };
 
     String TENABLE_API_URL = "https://cloud.tenable.com";
+    String ALL_SOURCES_ASSET_GROUP = "all-sources";
 }

--- a/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
+++ b/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
@@ -573,5 +573,5 @@ public interface Constants {
     } };
 
     String TENABLE_API_URL = "https://cloud.tenable.com";
-    String ALL_SOURCES_ASSET_GROUP = "all-sources";
+    String GROUP_NAME_FOR_ALL_SOURCES_ASSET_GROUP = "all-sources";
 }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tried to add redhat in new saasdev env
it was the first time for a plugin of type redhat
data collector and shipper ran successfully
https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/saasdev%2Fjobs/log-events/saasdev%2Fdefault%2Fbda8e156ba0c4eac8775238e8db74be2
asset group added
![image](https://github.com/PaladinCloud/CE/assets/114460784/27a88b20-61d3-4789-b661-819b1c870ab2)
plugin added and counts populated
![image](https://github.com/PaladinCloud/CE/assets/114460784/a7a3a41b-0ce6-46e6-ad34-53d9efda6e49)
redhat data available in all-sources
![image](https://github.com/PaladinCloud/CE/assets/114460784/7013bf56-1096-4a30-a9c0-1e4660e4e9a0)

Now deleting redhat plugin
---------
asset group removed
![image](https://github.com/PaladinCloud/CE/assets/114460784/3548214f-be25-419b-95ae-bd7b5fd0bb5c)
plugin removed
![image](https://github.com/PaladinCloud/CE/assets/114460784/a98af832-a87c-4bba-bfd3-e7bb78fe3346)
data removed from all-sources
![image](https://github.com/PaladinCloud/CE/assets/114460784/179082e4-e7cb-4338-b5c6-3bf40ca8b4a1)

Now adding redhat again to see if data is available in all-sources
-----------
data is back
![image](https://github.com/PaladinCloud/CE/assets/114460784/8cd0fbc5-8f40-4f93-8946-bd1b36e8c9ad)
![image](https://github.com/PaladinCloud/CE/assets/114460784/c527d5a9-f853-4579-a77c-0fb0ef22efea)

Deleted again to see how UI shows for all-sources
---
no more redhat in all-sources
![image](https://github.com/PaladinCloud/CE/assets/114460784/5ba371c4-6d13-4aa5-a31a-b0c0d5dbca39)
![image](https://github.com/PaladinCloud/CE/assets/114460784/5dc14c0d-e812-4d2c-9886-1dd0b97f3646)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
