### PR TITLE
fix:[CORE-1723] Update ES url to new index as per core-1647

### DIFF
--- a/installer/resources/pacbot_app/files/DB_Policy.sql
+++ b/installer/resources/pacbot_app/files/DB_Policy.sql
@@ -3440,6 +3440,7 @@ UPDATE cf_PolicyTable SET severity ='high' WHERE policyId = 'AWS_account_securit
 /* Updating target types for policies related to azure_kubernetes and gcp_gkecluster since targetName has changed */
 update cf_PolicyTable set targetType='aks', policyParams=replace(policyParams,'\"targetType\":\"kubernetes\"','\"targetType\":\"aks\"') where targetType='kubernetes' and assetGroup='azure';
 update cf_PolicyTable set targetType='gke', policyParams=replace(policyParams,'\"targetType\":\"gkecluster\"','\"targetType\":\"gke\"') where targetType='gkecluster' and assetGroup='gcp';
+update cf_PolicyParams set paramValue=replace(paramValue,'gcp_gkecluster','gcp_gke') where paramKey='esSgRulesUrl';
 
 DELETE IGNORE FROM  cf_PolicyTable  where policyId='AWSRdsUnencryptedPublicInstances_version-1_AwsRdsUnencryptedPublicAccess_rdsdb';
 DELETE IGNORE FROM  cf_PolicyParams where policyId='AWSRdsUnencryptedPublicInstances_version-1_AwsRdsUnencryptedPublicAccess_rdsdb';


### PR DESCRIPTION
# Description

- Issue is because the esSgRulesUrl in policyParams table is still pointing to old ES index even after reindexing gcp_gkecluster as per CORE-1647
- Fixed the esSgRulesUrl to point to the new index gcp_gke

Fixes # (issue)

esSgRulesUrl in policyParams table

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] verify the esSgRulesUrl in policyParams table url before the fix
- [x] verify the esSgRulesUrl in policyParams table url after the fix

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
