### PR TITLE
fix:[CORE-1535] Include only running ec2 assets for qualys policies

### DIFF
--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/service/ComplianceServiceImpl.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/service/ComplianceServiceImpl.java
@@ -607,8 +607,7 @@ public class ComplianceServiceImpl implements ComplianceService, Constants {
                                 issuecountPerPolicyAG = Long.parseLong(totaluntaggedStr);
                             }
                         } else {
-                            if ((policyId.contains(CLOUD_QUALYS_POLICY) && qualysEnabled)
-                                    || policyId.equalsIgnoreCase(SSM_AGENT_RULE)) {
+                            if (isQualysPolicy(policyId) || policyId.equalsIgnoreCase(SSM_AGENT_RULE)) {
                                 // qualys coverage require only running instances
                                 PolicyParams discoveredDayRangeParam = policyParamService.getPolicyParamsByPolicyIdAndKey(policyId,DISCOVERED_DAYS_RANGE);
                                 String discoverDayRange=discoveredDayRangeParam.getValue();
@@ -709,6 +708,10 @@ public class ComplianceServiceImpl implements ComplianceService, Constants {
         }
 
         return response;
+    }
+
+    private boolean isQualysPolicy(String policyId) {
+        return qualysEnabled && (policyId.contains(CLOUD_QUALYS_POLICY) || policyId.contains(CLOUD_QUALYS_POLICY_RULES));
     }
 
     private List<LinkedHashMap<String, Object>> filterPolicyComplianceData(List<LinkedHashMap<String, Object>> openIssuesByPolicyListFinal, Request request){

--- a/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
+++ b/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
@@ -442,6 +442,7 @@ public interface Constants {
     String AZURE_WINDOWS = "Windows";
     String CLOUD_KERNEL_COMPLIANCE_POLICY = "cloud-kernel-compliance_version-1";
     String CLOUD_QUALYS_POLICY = "Ec2InstanceScannedByQualys_version-1";
+    String CLOUD_QUALYS_POLICY_RULES = "Ec2WithSeverityVulnerability_version-1";
     String VIRTUALMACHINE_KERNEL_COMPLIANCE_RULE = "cloud-kernel-compliance_version-1_Virtualmachine-Kernel-Compliance-Rule_virtualmachine";
     String GCP = "gcp";
     String RESOLUTION_URL = "resolutionUrl";


### PR DESCRIPTION
# Description

- The issue is beacause for 'Enable Qualys EC2 Vulnerability Scan policy' only running ec2 assets are considered but for ‘Qualys Found S3/S4/S5 Vulnerabilities on EC2 Instance’ policies all ec2 assets are consider(both running and stopped) and thats the reason we see different asset count for these qualys policies.
- Fixed it by considering only running ec2 assets for all qualys policies.

Fixes # (issue)
Fixes the Assets scanned count for policy summary

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] We can reproduce this issue by going to policy summary in dashboard, filter by all the qualys policies and open the policy summary for 'Enable Qualys EC2 Vulnerability Scan policy' and ‘Qualys Found S3/S4/S5 Vulnerabilities on EC2 Instance’ policies. The total assets will not match.
- [ ] After the fix, verify the total assets match for all qualys policies summary

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
