### PR TITLE
fix:[CORE-1702] Set default logger level to ERROR for notification lamdas

### DIFF
--- a/lambda-functions/notification-es-logging-service/src/main/java/com/paladincloud/notification_log/LogNotificationToOpenSearch.java
+++ b/lambda-functions/notification-es-logging-service/src/main/java/com/paladincloud/notification_log/LogNotificationToOpenSearch.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SNSEvent;
 import com.amazonaws.services.lambda.runtime.events.SNSEvent.SNSRecord;
@@ -73,8 +72,7 @@ public class LogNotificationToOpenSearch implements RequestHandler<SNSEvent, Voi
 
 	@Override
 	public Void handleRequest(SNSEvent input, Context context) {
-		LambdaLogger logger = context.getLogger();
-		logger.log("Inside Notification Logger handlerRequest Method " + input);
+		LOGGER.info("Inside Notification Logger handlerRequest Method " + input);
 		List<SNSRecord> records = input.getRecords();
 		records.forEach(r -> {
 			String message = r.getSNS().getMessage();
@@ -90,12 +88,12 @@ public class LogNotificationToOpenSearch implements RequestHandler<SNSEvent, Voi
 				eventMap.put(LATEST, true);
 				eventMap.put("docType",NOTIFICATION_TYPE);
 				message = objectMapper.writeValueAsString(eventMap);
-				logger.log("message : " + message);
+				LOGGER.info("message : " + message);
 				boolean status = postJsonDocumentToIndexAndType(NOTIFICATION_INDEX, NOTIFICATION_TYPE, strUUID,
 						message);
-				logger.log("status : " + status);
+				LOGGER.info("status : " + status);
 			} catch (JsonProcessingException e) {
-				logger.log("json parse exception :"+e);
+				LOGGER.error("json parse exception :"+e);
 			}
 
 			

--- a/lambda-functions/notification-es-logging-service/src/main/resources/log4j2.xml
+++ b/lambda-functions/notification-es-logging-service/src/main/resources/log4j2.xml
@@ -7,7 +7,7 @@
     </Appenders>
     <Loggers>
 		<!-- avoid duplicated logs with additivity=false -->
-        <Logger name="com.paladincloud" level="info" additivity="false">
+        <Logger name="com.paladincloud" level="error" additivity="false">
             <AppenderRef ref="LogToConsole"/>
         </Logger>
         <Root level="error">

--- a/lambda-functions/notification-invoke-service/pom.xml
+++ b/lambda-functions/notification-invoke-service/pom.xml
@@ -13,6 +13,11 @@
 	</properties>
     <dependencies>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
             <version>1.2.1</version>
@@ -22,11 +27,7 @@
             <artifactId>aws-lambda-java-events</artifactId>
             <version>3.11.0</version>
         </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.5.1</version>
-        </dependency>
+
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/lambda-functions/notification-invoke-service/src/main/resources/log4j2.xml
+++ b/lambda-functions/notification-invoke-service/src/main/resources/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="LogToConsole" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+		<!-- avoid duplicated logs with additivity=false -->
+        <Logger name="com.paladincloud" level="${env:LOG_LEVEL:-ERROR}" additivity="false">
+            <AppenderRef ref="LogToConsole"/>
+        </Logger>
+        <Root level="error">
+            <AppenderRef ref="LogToConsole"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/lambda-functions/notification-send-email-service/pom.xml
+++ b/lambda-functions/notification-send-email-service/pom.xml
@@ -53,6 +53,11 @@
             <version>2.11.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.15.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/lambda-functions/notification-send-email-service/src/main/java/com/paladincloud/InvokeNotificationsApi.java
+++ b/lambda-functions/notification-send-email-service/src/main/java/com/paladincloud/InvokeNotificationsApi.java
@@ -1,44 +1,43 @@
 package com.paladincloud;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.LambdaLogger;
-import com.paladincloud.utils.HttpUtil;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.paladincloud.utils.HttpUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
 
 public class InvokeNotificationsApi {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InvokeNotificationsApi.class);
 
     public String handleRequest(Map<String,Object> event, Context context)
     {
         Gson gsonObj = new Gson();
-        LambdaLogger logger = context.getLogger();
 
         String response = new String("hello paladin cloud");
-        logger.log("inside handleRequest "+event);
+        LOGGER.info("inside handleRequest "+event);
         String jsonStr = gsonObj.toJson(event);
-        System.out.println("jsonStr -- "+jsonStr);
+        LOGGER.info("jsonStr -- "+jsonStr);
         JsonParser jsonParser = new JsonParser();
         JsonObject policyParamsJson = (JsonObject) jsonParser.parse(jsonStr);
 
         JsonElement bodyJson = policyParamsJson.getAsJsonArray("Records").get(0);
-        System.out.println("bodyJson--"+bodyJson.toString());
+        LOGGER.info("bodyJson--"+bodyJson.toString());
         String payload = bodyJson.getAsJsonObject().get("Sns").getAsJsonObject().get("Message").getAsString();
 
-        logger.log("payload for invoking notifications "+payload);
+        LOGGER.info("payload for invoking notifications "+payload);
 
         try {
             String invokeNotificationUrl = System.getenv("INVOKE_NOTIFICATION_URL");
             String token = HttpUtil.getToken();
-            logger.log(" token -"+token);
+            LOGGER.info(" token -"+token);
             String notificationSettingsJson = HttpUtil.post(invokeNotificationUrl,payload,token,"Bearer");
-            logger.log("notification settings response -"+notificationSettingsJson);
+            LOGGER.info("notification settings response -"+notificationSettingsJson);
 
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/lambda-functions/notification-send-email-service/src/main/java/com/paladincloud/utils/HttpUtil.java
+++ b/lambda-functions/notification-send-email-service/src/main/java/com/paladincloud/utils/HttpUtil.java
@@ -34,6 +34,8 @@ import org.apache.http.ssl.TrustStrategy;
 import org.apache.http.util.EntityUtils;
 
 import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -41,6 +43,7 @@ import com.google.common.base.Strings;
  */
 public class HttpUtil {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpUtil.class);
     private static final String API_READ_SCOPE = "API_OPERATION/READ";
 
     private HttpUtil() {
@@ -65,14 +68,14 @@ public class HttpUtil {
             if (entity != null) {
                 // return it as a String
                 result = EntityUtils.toString(entity);
-                System.out.println(result);
+                LOGGER.info(result);
             }
             if( httpResponse.getStatusLine().getStatusCode()==HttpStatus.SC_UNAUTHORIZED){
                 throw new Exception("User unauthorized !!");
             }
 
         } catch (Exception exception) {
-            System.out.println("Error inside fetch notification settings " + exception.getMessage());
+            LOGGER.error("Error inside fetch notification settings " + exception.getMessage());
         }
         return result;
     }
@@ -109,7 +112,7 @@ public class HttpUtil {
                 return EntityUtils.toString(httpresponse.getEntity());
             }
         } catch (Exception e) {
-            System.out.println("Error getting the data " +e.getMessage());
+            LOGGER.error("Error getting the data " +e.getMessage());
             throw e;
         }
         return null;
@@ -132,7 +135,7 @@ public class HttpUtil {
                         }
                     }).build()).build();
         } catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
-            System.out.println("Error getting getHttpClient "+e.getMessage());
+            LOGGER.error("Error getting getHttpClient "+e.getMessage());
         }
         return httpClient;
     }
@@ -141,7 +144,7 @@ public class HttpUtil {
             return new ObjectMapper().readValue(json, new TypeReference<Map<String, Object>>() {
             });
         } catch (IOException e) {
-            System.out.println("Error in parseJson "+e.getMessage());
+            LOGGER.error("Error in parseJson "+e.getMessage());
         }
         return new HashMap<>();
     }
@@ -173,7 +176,7 @@ public class HttpUtil {
                 .setDefaultCredentialsProvider(provider)
                 .build();
              CloseableHttpResponse httpResponse = httpClient.execute(request)) {
-            System.out.println("statuscode is "+httpResponse.getStatusLine().getStatusCode());
+            LOGGER.info("statuscode is "+httpResponse.getStatusLine().getStatusCode());
             if(httpResponse.getStatusLine().getStatusCode()!=200){
                 throw new Exception("Could not fetch topic arn for notification channels!");
             }

--- a/lambda-functions/notification-send-email-service/src/main/resources/log4j2.xml
+++ b/lambda-functions/notification-send-email-service/src/main/resources/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="LogToConsole" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+		<!-- avoid duplicated logs with additivity=false -->
+        <Logger name="com.paladincloud" level="${env:LOG_LEVEL:-ERROR}" additivity="false">
+            <AppenderRef ref="LogToConsole"/>
+        </Logger>
+        <Root level="error">
+            <AppenderRef ref="LogToConsole"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/lambda-functions/notification-template-formatter-service/pom.xml
+++ b/lambda-functions/notification-template-formatter-service/pom.xml
@@ -24,11 +24,6 @@
         <version>3.11.0</version>
     </dependency>
     <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-lambda-java-log4j2</artifactId>
-        <version>1.5.1</version>
-    </dependency>
-    <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.10</version>
@@ -62,6 +57,11 @@
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.15.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/lambda-functions/notification-template-formatter-service/src/main/java/com/paladincloud/HttpUtil.java
+++ b/lambda-functions/notification-template-formatter-service/src/main/java/com/paladincloud/HttpUtil.java
@@ -1,7 +1,6 @@
 package com.paladincloud;
 
 import java.io.*;
-import java.nio.charset.Charset;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -13,7 +12,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.http.HttpEntity;
@@ -36,6 +34,8 @@ import org.apache.http.ssl.TrustStrategy;
 import org.apache.http.util.EntityUtils;
 
 import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.paladincloud.Constants.*;
 
@@ -44,6 +44,7 @@ import static com.paladincloud.Constants.*;
  */
 public class HttpUtil {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpUtil.class);
     private static final String API_READ_SCOPE = "API_OPERATION/READ";
 
     private HttpUtil() {
@@ -68,14 +69,14 @@ public class HttpUtil {
             if (entity != null) {
                 // return it as a String
                 result = EntityUtils.toString(entity);
-                System.out.println(result);
+                LOGGER.info(result);
             }
             if( httpResponse.getStatusLine().getStatusCode()==HttpStatus.SC_UNAUTHORIZED){
                     throw new Exception("User unauthorized !!");
                 }
 
         } catch (Exception exception) {
-            System.out.println("Error inside fetch notification settings " + exception.getMessage());
+            LOGGER.error("Error inside fetch notification settings " + exception.getMessage());
         }
         return result;
 }
@@ -112,7 +113,7 @@ public class HttpUtil {
                 return EntityUtils.toString(httpresponse.getEntity());
             }
         } catch (Exception e) {
-            System.out.println("Error getting the data " +e.getMessage());
+            LOGGER.error("Error getting the data " +e.getMessage());
             throw e;
         }
         return null;
@@ -135,7 +136,7 @@ public class HttpUtil {
                         }
                     }).build()).build();
         } catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
-            System.out.println("Error getting getHttpClient "+e.getMessage());
+            LOGGER.error("Error getting getHttpClient "+e.getMessage());
         }
         return httpClient;
     }
@@ -144,7 +145,7 @@ public class HttpUtil {
             return new ObjectMapper().readValue(json, new TypeReference<Map<String, Object>>() {
             });
         } catch (IOException e) {
-            System.out.println("Error in parseJson "+e.getMessage());
+            LOGGER.error("Error in parseJson "+e.getMessage());
         }
         return new HashMap<>();
     }
@@ -176,7 +177,7 @@ public class HttpUtil {
                 .setDefaultCredentialsProvider(provider)
                 .build();
              CloseableHttpResponse httpResponse = httpClient.execute(request)) {
-            System.out.println("statuscode is "+httpResponse.getStatusLine().getStatusCode());
+            LOGGER.info("statuscode is "+httpResponse.getStatusLine().getStatusCode());
             if(httpResponse.getStatusLine().getStatusCode()!=200){
                 throw new Exception("Could not fetch topic arn for notification channels!");
             }
@@ -191,7 +192,7 @@ public class HttpUtil {
 
                     topicArnDetailsMap.put("email", sourceJson.get(mailTopicArn).getAsString());
                     topicArnDetailsMap.put(apiauthinfo, sourceJson.get(apiauthinfo).getAsString());
-                    System.out.println(result);
+                    LOGGER.info(result);
                 }
             }
         }

--- a/lambda-functions/notification-template-formatter-service/src/main/resources/log4j2.xml
+++ b/lambda-functions/notification-template-formatter-service/src/main/resources/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="LogToConsole" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+		<!-- avoid duplicated logs with additivity=false -->
+        <Logger name="com.paladincloud" level="${env:LOG_LEVEL:-ERROR}" additivity="false">
+            <AppenderRef ref="LogToConsole"/>
+        </Logger>
+        <Root level="error">
+            <AppenderRef ref="LogToConsole"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
# Description

- Issue was when notification lambdas log everything including request(which contains violation info that has "error" text in it), ops alert is generated
- Fixed it by making default log level to error in log4j2.xml config file
- the default log level can be overriden by setting an env variable LOG_LEVEL=<DEBUG/INFO/WARN/ERROR>, so that log level can be set to INFO only for dev env
- for all other envs except dev, we dont need to set the env variable, since ERROR will be the default level

Fixes # (issue)
ops alert for notification lambdas

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] execute the lambda fn without setting the LOG_LEVEL env variable. cloudwatch logs shouldn't contain logs that are below ERROR level
- [ ] execute the lambda fn after setting the LOG_LEVEL env variable to INFO. cloudwatch logs should contain all logs starting from INFO level

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
