### PR TITLE
Fix/UI ux 550/asset details red hat logo

### DIFF
--- a/webapp/src/app/pacman-features/modules/assets/asset-details/asset-details.component.ts
+++ b/webapp/src/app/pacman-features/modules/assets/asset-details/asset-details.component.ts
@@ -370,7 +370,7 @@ export class AssetDetailsComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   assignCloudType(event:string){
-    const cloudType = event?.toLowerCase();
+    const cloudType = event?.toLowerCase()?.replace(/\s/g, '');
     this.tiles["Asset"].img = cloudType;
     this.cdRef.detectChanges();
   }


### PR DESCRIPTION
# Description

Bug: [Asset Details] The Red Hat Source logo is not loading.
https://paladincloud.atlassian.net/browse/UIUX-550

Fixes # (issue) 
The issue was caused by a white space in the image name. It has been resolved by removing the white space.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

Bug: 

<img width="1383" alt="Screenshot 2023-12-05 at 6 38 34 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/48e95c6e-513f-4139-a965-267dda8c70b9">

Fix:

<img width="1397" alt="Screenshot 2023-12-05 at 6 38 51 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/2012b203-f717-443d-9a0b-76814514c60a">


List any documentation updates that are needed for the Wiki