### PR TITLE
fix:[CORE-1781] policy api failing if policy name filter value has si…

### DIFF
--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/repository/ComplianceRepositoryImpl.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/repository/ComplianceRepositoryImpl.java
@@ -3180,7 +3180,7 @@ public class ComplianceRepositoryImpl implements ComplianceRepository, Constants
         List<String> value = filter.containsKey(filterName) ? (List<String>) filter.get(filterName) : new ArrayList<>();
         String template = " %s in ( %s ) ";
         if (!value.isEmpty()) {
-            filterConditions.add(String.format(template, column, value.stream().map(str -> "'" + str + "'").collect(Collectors.joining(","))));
+            filterConditions.add(String.format(template, column, value.stream().map(str -> "'" + str.replaceAll("'","\\\\'") + "'").collect(Collectors.joining(","))));
         }
     }
 


### PR DESCRIPTION
…ngle quote

# Description

If policy name contain single quote and it is passed in filter, then mysql query is failing because single quote is not escaped in query. Adding backslash prefix to single quotes inside policy name.

![image](https://github.com/PaladinCloud/CE/assets/84776630/4b1e9fd5-67a9-448b-816b-66ba49eea00c)


Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
