### PR TITLE
fix:[CORE-1728] Default region for violations must be 'global'

### DIFF
--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/repository/ComplianceRepositoryImpl.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/repository/ComplianceRepositoryImpl.java
@@ -103,6 +103,8 @@ import com.tmobile.pacman.api.compliance.domain.ResponseWithOrder;
 import com.tmobile.pacman.api.compliance.domain.PolicyDetails;
 import com.tmobile.pacman.api.compliance.service.NotificationService;
 
+import static com.tmobile.pacman.api.compliance.util.Constants.GLOBAL;
+
 /**
  * The Class ComplianceRepositoryImpl.
  */
@@ -1600,7 +1602,7 @@ public class ComplianceRepositoryImpl implements ComplianceRepository, Constants
             if (domain.equals(INFRA_AND_PLATFORMS)) {
                 issue.put(ACCOUNT_DISPALY_NAME, sourceMap.get(ACCOUNT_NAME));
                 issue.put(ACCOUNT_DISPLAYI_D, sourceMap.get(ACCOUNT_ID));
-                issue.put(REGION_DISPALY_NAME, sourceMap.get(REGION));
+                issue.put(REGION_DISPALY_NAME, sourceMap.get(REGION) == null ? GLOBAL : sourceMap.get(REGION));
             }
             issue.put(CREATED_DISPLAY_DATE, sourceMap.get(CREATED_DATE));
             issue.put(MODIFIED_DISPLAY_DATE, sourceMap.get(MODIFIED_DATE));

--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/util/Constants.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/util/Constants.java
@@ -16,4 +16,6 @@ public final class Constants {
     public static final String CANCEL_EXEMPTION_REQUEST_EVENT_NAME  = "Exemption request revoked for resource - %s";
     public static final String APPROVE_EXEMPTION_REQUEST_EVENT_NAME  = "Exemption request approved for resource - %s";
     public static final String EMAIL = "email";
+
+    public static final String GLOBAL = "global";
 }


### PR DESCRIPTION
# Description

the violations of the assets that doesn't have specific region shows up as 'No data' in violations screen
fixed this by setting default region as global if there is no specific region
jira link: https://paladincloud.atlassian.net/browse/CORE-1728

Fixes # (issue)
Fixes /issues violation API where there is no specific region

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Check the /issues API response for violation of assets without a specific region
- [ ] the region must be 'global' for all those assets

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
