### PR TITLE
fix:[CORE-1602] Delete duplicate azure policy 'Enable Transparent Data Encryption on SQL Databases'

### DIFF
--- a/installer/resources/pacbot_app/files/DB_Policy.sql
+++ b/installer/resources/pacbot_app/files/DB_Policy.sql
@@ -3517,3 +3517,8 @@ UPDATE cf_PolicyTable SET policyDisplayName = 'Set the Rotation Period of IAM Ac
 UPDATE cf_PolicyTable SET policyDisplayName = 'EC2 Instance Stopped more than N days' WHERE policyId ='Ec2StoppedInstanceForLong_version-1_Ec2StoppedInstanceForLong_ec2';
 
 UPDATE cf_PolicyTable SET category='security' WHERE policyId in ('AccountEnsureCloudwatchAlarmExistsForSecurityGroupChanges_version-1_EnableCloudwatchAlarm_account','Ensure_clusters_created_with_pvtnodes','Enable_Cloud_Logging_Monitoring','Enable_Integrity_Monitoring_For_Node_Pool','Enable_Secure_Boot_For_Node_Pool','Enable_VPC_Flow_Logs_and_IntraNode_Visibility');
+
+DELETE IGNORE FROM cf_PolicyExemption where policyId='Data_Encryption_SQL_version-1_SDE_sqldatabase';
+DELETE IGNORE FROM cf_PolicyPackRuleInfo where policyId='Data_Encryption_SQL_version-1_SDE_sqldatabase';
+DELETE IGNORE FROM cf_PolicyParams where policyID='Data_Encryption_SQL_version-1_SDE_sqldatabase';
+DELETE IGNORE FROM cf_PolicyTable where policyId='Data_Encryption_SQL_version-1_SDE_sqldatabase';

--- a/installer/resources/pacbot_app/files/DB_Policy.sql
+++ b/installer/resources/pacbot_app/files/DB_Policy.sql
@@ -3519,6 +3519,5 @@ UPDATE cf_PolicyTable SET policyDisplayName = 'EC2 Instance Stopped more than N 
 UPDATE cf_PolicyTable SET category='security' WHERE policyId in ('AccountEnsureCloudwatchAlarmExistsForSecurityGroupChanges_version-1_EnableCloudwatchAlarm_account','Ensure_clusters_created_with_pvtnodes','Enable_Cloud_Logging_Monitoring','Enable_Integrity_Monitoring_For_Node_Pool','Enable_Secure_Boot_For_Node_Pool','Enable_VPC_Flow_Logs_and_IntraNode_Visibility');
 
 DELETE IGNORE FROM cf_PolicyExemption where policyId='Data_Encryption_SQL_version-1_SDE_sqldatabase';
-DELETE IGNORE FROM cf_PolicyPackRuleInfo where policyId='Data_Encryption_SQL_version-1_SDE_sqldatabase';
 DELETE IGNORE FROM cf_PolicyParams where policyID='Data_Encryption_SQL_version-1_SDE_sqldatabase';
 DELETE IGNORE FROM cf_PolicyTable where policyId='Data_Encryption_SQL_version-1_SDE_sqldatabase';


### PR DESCRIPTION
# Description

- deleted the policy  'Enable Transparent Data Encryption on SQL Databases' with policyId 'Data_Encryption_SQL_version-1_SDE_sqldatabase' from rds tables, since it is a duplicate of 'Enable Transparent Data Encryption for SQL Database'
- attached ES query to remove related violation documents

Fixes # (issue)
Removes the policy 'Enable Transparent Data Encryption on SQL Databases' 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] check both the user and admin Policies screen. This policy 'Enable Transparent Data Encryption on SQL Databases' must not be present
- [ ] Violations for this policy are not seen in violation screen

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
