### PR TITLE
chore:Removed Policy(ec2 shouldn't access 3306)

### DIFF
--- a/installer/resources/lambda_rule_engine/files/rule_engine_cloudwatch_aws_rules.json
+++ b/installer/resources/lambda_rule_engine/files/rule_engine_cloudwatch_aws_rules.json
@@ -78,7 +78,6 @@
 	"aws_classicelb_access_logs",
 	"aws_ec2_should_not_be_stopped_state_for_too_long",
 	"aws_ec2_should_not_be_publicly_accessible_on_port1434",
-	"aws_ec2_should_not_be_publicly_accessible_on_port3306",
 	"aws_ec2_should_not_be_publicly_accessible_on_port138",
 	"aws_ec2_should_not_be_publicly_accessible_on_port80",
 	"aws_ec2_should_not_be_publicly_accessible_on_port8080",


### PR DESCRIPTION
# Description

Removed Policy id aws_ec2_should_not_be_publicly_accessible_on_port3306 
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
