### PR TITLE
fix:[CORE-1702] Update the lambda path

### DIFF
--- a/installer/settings/common.py
+++ b/installer/settings/common.py
@@ -82,7 +82,7 @@ PROCESS_RESOURCES = {
 }
 
 
-LAMBDA_PATH = "V10"
+LAMBDA_PATH = "V11"
 DATA_DIR = os.path.join(BASE_APP_DIR, 'data')
 LOG_DIR = os.path.join(BASE_APP_DIR, 'log')
 PROVISIONER_FILES_DIR_TO_COPY = os.path.join(BASE_APP_DIR, 'files')


### PR DESCRIPTION
# Description

- issue was that, LAMBDA_PATH wasn't updated after the lambda changes done in CORE-1702
- bumped the LAMBDA_PATH version

Fixes # (issue)
LAMBDA_PATH version

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] execute the lambda fn without setting the LOG_LEVEL env variable. cloudwatch logs shouldn't contain logs that are below ERROR level

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
