### PR TITLE
fix:[CUS-239] asset trend graph for asset type in a asset group

### DIFF
--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/controller/AssetTrendController.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/controller/AssetTrendController.java
@@ -90,7 +90,7 @@ public class AssetTrendController {
         }
     }
 
-    @ApiOperation(value = "Trends of daily total assets count over the period of last 1 month", response = Iterable.class)
+    @ApiOperation(value = "Trends of daily total assets count over the period between from and to date", response = Iterable.class)
     @GetMapping(path = "/v1/trend/assetcount")
     public ResponseEntity<Object> getAssetCount(@RequestParam(name = "ag", required = true) String assetGroup,
                                                       @RequestParam(name = "type", required = false) String type,

--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/repository/AssetRepositoryImpl.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/repository/AssetRepositoryImpl.java
@@ -2984,13 +2984,12 @@ public class AssetRepositoryImpl implements AssetRepository {
 
         List<Map<String, Object>> assetCountList = new ArrayList<>();
         try {
-
+            String docType = !Strings.isNullOrEmpty(type) ? "count_type" : "count_asset";
             StringBuilder request = new StringBuilder(
-                    // "{\"size\": 10000, \"_source\": [\"count\",\"ag\",\"date\"],  \"query\": { \"bool\": { \"must\": [ { \"match\": {\"ag.keyword\": ");
-                    "{\"size\": 10000,  \"query\": { \"bool\": { \"must\": [ {\"term\":{\"docType.keyword\":\"count_asset\"}}, { \"match\": {\"ag.keyword\": ");
+                    "{\"size\": 10000,  \"query\": { \"bool\": { \"must\": [ {\"term\":{\"docType.keyword\":\"" + docType + "\"}}, { \"term\": {\"ag.keyword\": ");
             request.append("\"" + assetGroup + "\"}}");
             if(type!=null){
-                //request.append(",{ \"match\": {\"type.keyword\": " + "\"" + type + "\"}}");
+                request.append(",{ \"term\": {\"type.keyword\": " + "\"" + type + "\"}}");
             }
             String gte = null;
             String lte = null;
@@ -3041,6 +3040,10 @@ public class AssetRepositoryImpl implements AssetRepository {
                     Map<String, Object> doc = new Gson().fromJson(sourceJson, new TypeToken<Map<String, Object>>() {
                     }.getType());
                     doc.remove("assetCount");
+                    if ("count_type".equalsIgnoreCase((String) doc.get("docType"))) {
+                        doc.put("totalassets", doc.get("max") != null ? Math.round(Double.parseDouble(doc.get("max").toString())) : 0);
+                    }
+                    doc.keySet().retainAll(Arrays.asList("date", "ag", "totalassets","type"));
                     docs.add(doc);
                 }
             }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

This feature is to enable api/asset/v1/trend/assetcount api to return number of assets date wise for each asset type also. Presently it is returning total assets of asset group only.

assettrendgraph

![ce-cus239](https://github.com/PaladinCloud/CE/assets/84776630/0bec9200-737a-400d-b61b-f137a70ddcb6)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
