### PR TITLE
fix:[CORE-1816]fixed filters not working when value contains = operator

### DIFF
--- a/webapp/src/app/shared/services/utils.service.ts
+++ b/webapp/src/app/shared/services/utils.service.ts
@@ -260,7 +260,7 @@ export class UtilsService {
         const eachFilterParam = element.split('=');
         const key = eachFilterParam[0];
         const value = eachFilterParam[1];
-        object[key] = value;
+        object[key] = decodeURIComponent(value);
       });
     } else {
       object = {};
@@ -285,7 +285,7 @@ export class UtilsService {
         const localObjKeys = Object.keys(data);
         each(localObjKeys, (element, index) => {
           if (typeof data[element] !== 'undefined') {
-            const localValue = data[element].toString();
+            const localValue = encodeURIComponent(data[element].toString());
             const localKeys = element.toString();
             const localObj = localKeys + '=' + localValue;
             localArray.push(localObj);


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.
UI has a logic which splits the filter key-value string based on '=' operator.
In this fix, We are trying to encode the filter values and decode them so that they are not split based on '='.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration
Test results:
Now, the filter values containing '=' operator will work as expected

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
