### PR TITLE
fix:[CORE-1728] Region for global assets must be 'global' instead of 'No Data'

### DIFF
--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/InventoryConstants.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/InventoryConstants.java
@@ -25,4 +25,6 @@ public class InventoryConstants {
     /** The Constant INVENTORY. */
     public static final String SUBSCRIPTION_NAME = "subscriptionName";
 	public static final String CONFIG_CREDS = "config_creds";
+
+    public static final String REGION_GLOBAL = "global";
 }

--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/PolicyDefinitionInventoryCollector.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/PolicyDefinitionInventoryCollector.java
@@ -15,6 +15,8 @@ import com.tmobile.pacbot.azure.inventory.auth.AzureCredentialProvider;
 import com.tmobile.pacbot.azure.inventory.vo.PolicyDefinitionVH;
 import com.tmobile.pacbot.azure.inventory.vo.SubscriptionVH;
 
+import static com.tmobile.pacbot.azure.inventory.InventoryConstants.REGION_GLOBAL;
+
 @Component
 public class PolicyDefinitionInventoryCollector {
 	
@@ -37,6 +39,7 @@ public class PolicyDefinitionInventoryCollector {
 			policyDefinitionVH.setPolicyRule(policyDefinition.policyRule().toString());
 			policyDefinitionVH.setSubscription(subscription.getSubscriptionId());
 			policyDefinitionVH.setSubscriptionName(subscription.getSubscriptionName());
+			policyDefinitionVH.setRegion(REGION_GLOBAL);
 			policyDefinitionList.add(policyDefinitionVH);
 		}
 		log.info("Target Type : {}  Total: {} ","Policy Defintion",policyDefinitionList.size());

--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/SecurityPricingsInventoryCollector.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/SecurityPricingsInventoryCollector.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,8 @@ import com.tmobile.pacbot.azure.inventory.auth.AzureCredentialProvider;
 import com.tmobile.pacbot.azure.inventory.vo.SecurityPricingsVH;
 import com.tmobile.pacbot.azure.inventory.vo.SubscriptionVH;
 import com.tmobile.pacman.commons.utils.CommonUtils;
+
+import static com.tmobile.pacbot.azure.inventory.InventoryConstants.REGION_GLOBAL;
 
 @Component
 public class SecurityPricingsInventoryCollector {
@@ -48,7 +51,7 @@ public class SecurityPricingsInventoryCollector {
 				securityPricingsVH.setType(securityPricingsObject.get("type").getAsString());
 				securityPricingsVH.setSubscription(subscription.getSubscriptionId());
 				securityPricingsVH.setSubscriptionName(subscription.getSubscriptionName());
-				securityPricingsVH.setRegion(Util.getRegionValue(subscription,subscription.getRegion()));
+				securityPricingsVH.setRegion(Util.getRegionValue(subscription, StringUtils.defaultIfBlank(subscription.getRegion(), REGION_GLOBAL)));
 				securityPricingsVH.setResourceGroupName(Util.getResourceGroupNameFromId(securityPricingsObject.get("id").getAsString()));
 
 				if (properties != null) {

--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/SubscriptionInventoryCollector.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/SubscriptionInventoryCollector.java
@@ -25,6 +25,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import static com.tmobile.pacbot.azure.inventory.InventoryConstants.REGION_GLOBAL;
+
 @Component
 public class SubscriptionInventoryCollector {
 
@@ -47,6 +49,7 @@ public class SubscriptionInventoryCollector {
         subscriptionVH.setStorageAccountLogList(fetchStorageAccountActivityLog(subscriptionVH));
         subscriptionVH.setRoleDefinitionList(fetchAzureRoleDefinition(subscriptionVH));
         subscriptionVH.setName(subscription.getSubscriptionName());
+        subscriptionVH.setRegion(REGION_GLOBAL);
 
         subscriptionList.add(subscriptionVH);
 

--- a/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/InventoryConstants.java
+++ b/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/InventoryConstants.java
@@ -81,4 +81,6 @@ public final class InventoryConstants {
 
     /** The rds pwd. */
     public static final String RDS_PWD = "spring.datasource.password";
+
+    public static final String REGION_GLOBAL = "global";
 }

--- a/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/file/FileManager.java
+++ b/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/file/FileManager.java
@@ -1120,7 +1120,7 @@ public class FileManager {
 		String fieldNames;
 		String keys;
 		fieldNames = "check.Id`check.Category`status`check.name`check.Description";
-		keys = "discoverydate`accountid`accountname`checkid`checkcategory`status`checkname`checkdescription";
+		keys = "discoverydate`accountid`accountname`region`checkid`checkcategory`status`checkname`checkdescription";
 		FileGenerator.generateJson(checksMap, fieldNames, "aws-checks.data",keys);
 
 		Iterator<Entry<String, List<CheckVH>>> it = checksMap.entrySet().iterator();
@@ -1138,7 +1138,7 @@ public class FileManager {
 		}
 
 		fieldNames = "checkid`id`status`data";
-		keys = "discoverydate`accountid`accountname`checkid`id`status`resourceinfo";
+		keys = "discoverydate`accountid`accountname`region`checkid`id`status`resourceinfo";
 		FileGenerator.generateJson(resourceMap, fieldNames, "aws-checks-resources.data",keys);
 
 	}
@@ -1259,10 +1259,10 @@ public class FileManager {
 		String fieldNames;
 		String keys;
 		fieldNames = "user.username`user.userid`user.arn`user.CreateDate`user.path`passwordCreationDate`user.PasswordLastUsed`passwordResetRequired`mfa`groups";
-		keys = "discoverydate`accountid`accountname`username`userid`arn`createdate`path`passwordcreationdate`passwordlastused`passwordresetrequired`mfaenabled`groups";
+		keys = "discoverydate`accountid`accountname`region`username`userid`arn`createdate`path`passwordcreationdate`passwordlastused`passwordresetrequired`mfaenabled`groups";
 		FileGenerator.generateJson(userMap, fieldNames, "aws-iamuser.data",keys);
 		fieldNames = "user.username`accessKeys.AccessKeyId`accessKeys.CreateDate`accessKeys.status`accessKeys.lastUsedDate";
-		keys = "discoverydate`accountid`accountname`username`accesskey`createdate`status`lastuseddate";
+		keys = "discoverydate`accountid`accountname`region`username`accesskey`createdate`status`lastuseddate";
 		FileGenerator.generateJson(userMap, fieldNames, "aws-iamuser-keys.data",keys);
 
 	}
@@ -1298,7 +1298,7 @@ public class FileManager {
 		String fieldNames;
 		String keys;
 		fieldNames = "roleName`roleId`arn`description`path`createDate`assumeRolePolicyDocument";
-		keys = "discoverydate`accountid`accountname`rolename`roleid`rolearn`description`path`createdate`assumedpolicydoc";
+		keys = "discoverydate`accountid`accountname`region`rolename`roleid`rolearn`description`path`createdate`assumedpolicydoc";
 		FileGenerator.generateJson(iamRoleMap, fieldNames, "aws-iamrole.data",keys);
 	}
 
@@ -1364,11 +1364,11 @@ public class FileManager {
 		fieldNames = "distSummary.id`distSummary.aRN`distSummary.status`distSummary.lastModifiedTime`distSummary.domainName`distSummary.enabled"
 				+"`distSummary.comment`distSummary.priceClass`distSummary.webACLId`distSummary.httpVersion`distSummary.isIPV6Enabled`distSummary.viewerCertificate.iAMCertificateId"
 				+"`distSummary.viewerCertificate.aCMCertificateArn`distSummary.viewerCertificate.cloudFrontDefaultCertificate`distSummary.viewerCertificate.sSLSupportMethod`distSummary.viewerCertificate.minimumProtocolVersion`distSummary.aliases.items`bucketName`accessLogEnabled`defaultRootObject";
-		keys = "discoverydate`accountid`accountname`id`arn`status`lastmodifiedtime`domainName`enabled`comment`priceclass`webaclid`httpversion`ipv6enabled`viewercertificateid"
+		keys = "discoverydate`accountid`accountname`region`id`arn`status`lastmodifiedtime`domainName`enabled`comment`priceclass`webaclid`httpversion`ipv6enabled`viewercertificateid"
 				+"`viewercertificatearn`viewercertificatedefaultcertificate`viewercertificatesslsupportmethod`viewercertificateminprotocolversion`aliases`bucketname`accesslogenabled`defaultRootObject";
 		FileGenerator.generateJson(cfMap, fieldNames, "aws-cloudfront.data",keys);
 		fieldNames = "distSummary.id`tags.key`tags.value";
-		keys = "discoverydate`accountid`accountname`id`key`value";
+		keys = "discoverydate`accountid`accountname`region`id`key`value";
 		FileGenerator.generateJson(cfMap, fieldNames, "aws-cloudfront-tags.data",keys);
 	}
 
@@ -1416,11 +1416,11 @@ public class FileManager {
 		fieldNames = "eventDetails.event.arn`eventDetails.event.service`eventDetails.event.eventTypeCode`eventDetails.event.eventTypeCategory`eventDetails.event.region`"
 				+"eventDetails.event.availabilityZone`eventDetails.event.startTime`eventDetails.event.endTime`eventDetails.event.lastUpdatedTime`eventDetails.event.statusCode"
 				+"`eventDetails.eventDescription.latestDescription`eventDetails.eventMetadata";
-		keys = "discoverydate`accountid`accountname`eventarn`eventservice`eventtypecode`eventtypecategory`eventregion`availabilityzone`starttime`endtime`"
+		keys = "discoverydate`accountid`accountname`region`eventarn`eventservice`eventtypecode`eventtypecategory`eventregion`availabilityzone`starttime`endtime`"
 				+"lastupdatedtime`statuscode`latestdescription`eventmetadata";
 		FileGenerator.generateJson(phdMap, fieldNames, "aws-phd.data",keys);
 		fieldNames = "affectedEntities.eventArn`affectedEntities.entityArn`affectedEntities.awsAccountId`affectedEntities.entityValue`affectedEntities.lastUpdatedTime`affectedEntities.statusCode`affectedEntities.tags";
-		keys = "discoverydate`accountid`accountname`eventarn`entityarn`awsaccountid`entityvalue`lastupdatedtime`statuscode`tags";
+		keys = "discoverydate`accountid`accountname`region`eventarn`entityarn`awsaccountid`entityvalue`lastupdatedtime`statuscode`tags";
 		FileGenerator.generateJson(phdMap, fieldNames, "aws-phd-entities.data",keys);
 	}
 
@@ -1918,7 +1918,7 @@ public class FileManager {
 		String fieldNames;
 		String keys;
 		fieldNames = "serverCertificateName`arn`expiryDate";
-		keys = "discoverydate`accountid`accountname`servercertificatename`arn`expirydate";
+		keys = "discoverydate`accountid`accountname`region`servercertificatename`arn`expirydate";
 		FileGenerator.generateJson(iamCertificate, fieldNames, "aws-iamcertificate.data", keys);
 	}
 
@@ -1932,7 +1932,7 @@ public class FileManager {
 		String fieldNames;
 		String keys;
 		fieldNames = "cloudtrailName`securityTopicARN`securityTopicEndpoint";
-		keys = "discoverydate`accountid`accountname`cloudtrailname`securitytopicarn`securitytopicendpoint";
+		keys = "discoverydate`accountid`accountname`region`cloudtrailname`securitytopicarn`securitytopicendpoint";
 		FileGenerator.generateJson(account, fieldNames, "aws-account.data", keys);
 	}
 	/**
@@ -1945,7 +1945,7 @@ public class FileManager {
 		String fieldNames;
 		String keys;
 		fieldNames = "group.groupName`group.groupID`group.arn`group.createDate`policies";
-		keys = "discoverydate`accountid`accountname`groupname`groupid`grouparn`createdate`policies";
+		keys = "discoverydate`accountid`accountname`region`groupname`groupid`grouparn`createdate`policies";
 		FileGenerator.generateJson(iamGroupMap, fieldNames, "aws-iamgroup.data", keys);
 	}
 	/**
@@ -2016,7 +2016,7 @@ public class FileManager {
 		String fieldNames;
 		String keys;
 		fieldNames = "policyName`policyId`arn`defaultVersionId`createDate";
-		keys = "discoverydate`accountid`accountname`policyname`policyid`policyarn`defaultversionid`createdate";
+		keys = "discoverydate`accountid`accountname`region`policyname`policyid`policyarn`defaultversionid`createdate";
 		FileGenerator.generateJson(map, fieldNames, "aws-iampolicies.data", keys);
 	}
 

--- a/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/util/InventoryUtil.java
+++ b/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/util/InventoryUtil.java
@@ -288,6 +288,8 @@ import com.tmobile.cso.pacman.inventory.file.FileGenerator;
 import com.amazonaws.services.docdb.AmazonDocDB;
 import com.amazonaws.services.docdb.AmazonDocDBClientBuilder;
 
+import static com.tmobile.cso.pacman.inventory.InventoryConstants.REGION_GLOBAL;
+
 /**
  * The Class InventoryUtil.
  */
@@ -1940,7 +1942,7 @@ public class InventoryUtil {
 			}
 		}
 		if (!checkList.isEmpty()) {
-			checkMap.put(accountId + delimiter + accountName, checkList);
+			checkMap.put(accountId + delimiter + accountName + delimiter + REGION_GLOBAL, checkList);
 		}
 		return checkMap;
 	}
@@ -2214,7 +2216,7 @@ public class InventoryUtil {
 
 		List<UserVH> userList = new ArrayList<>();
 		Map<String,List<UserVH>> iamUsers = new HashMap<>();
-		iamUsers.put(accountId+delimiter+accountName, userList);
+		iamUsers.put(accountId + delimiter + accountName + delimiter + REGION_GLOBAL, userList);
 		users.parallelStream().forEach(user -> {
 			UserVH userTemp = new UserVH(user);
 			String userName = user.getUserName();
@@ -2283,7 +2285,7 @@ public class InventoryUtil {
 
 		log.debug(InventoryConstants.ACCOUNT + accountId +" Type : IAM Roles >> "+roles.size());
 		Map<String,List<Role>> iamRoles = new HashMap<>();
-		iamRoles.put(accountId+delimiter+accountName, roles);
+		iamRoles.put(accountId + delimiter + accountName + delimiter + REGION_GLOBAL, roles);
 		return iamRoles;
 	}
 
@@ -2437,7 +2439,7 @@ public class InventoryUtil {
 			setConfigDetails(temporaryCredentials,cloudFrontList);
 
 			log.debug(InventoryConstants.ACCOUNT + accountId +" Type : CloudFront "+ " >> "+cloudFrontList.size());
-			cloudFront.put(accountId+delimiter+accountName,cloudFrontList);
+			cloudFront.put(accountId + delimiter + accountName + delimiter + REGION_GLOBAL, cloudFrontList);
 		}catch(Exception e){
 			log.error(expPrefix+ InventoryConstants.ERROR_CAUSE +e.getMessage()+"\"}");
 			ErrorManageUtil.uploadError(accountId,"","cloudfront",e.getMessage());
@@ -2599,7 +2601,7 @@ public class InventoryUtil {
 			}
 			if( !phdList.isEmpty() ) {
 				log.debug(InventoryConstants.ACCOUNT + accountId +" Type : PHD "+ " >> "+phdList.size());
-				phd.put(accountId+delimiter+accountName,phdList);
+				phd.put(accountId + delimiter + accountName + delimiter + REGION_GLOBAL, phdList);
 			}
 		}
 		catch(Exception e){
@@ -2750,7 +2752,7 @@ public class InventoryUtil {
 						iamCertVH.setExpiryDate(expiryDate);
 						iamCerttList.add(iamCertVH);
 					}
-					iamCertificateVH.put(account+delimiter+accountName, iamCerttList);
+						iamCertificateVH.put(account + delimiter + accountName + delimiter + REGION_GLOBAL, iamCerttList);
 					}else {
 						log.info("List is empty");
 					}
@@ -2840,7 +2842,7 @@ public class InventoryUtil {
 					synchronized (accountList) {
 						accountList.add(accountObj);
 					}
-					accountInfoList.put(account+delimiter+accountName, accountList);
+					accountInfoList.put(account + delimiter + accountName + delimiter + REGION_GLOBAL, accountList);
 					break;
 				}
 			} catch (Exception e) {
@@ -2873,7 +2875,7 @@ public class InventoryUtil {
 
 		List<GroupVH> groupList = new ArrayList<>();
 		Map<String,List<GroupVH>> iamGroups = new HashMap<>();
-		iamGroups.put(account+delimiter+accountName,  groupList);
+		iamGroups.put(account + delimiter + accountName + delimiter + REGION_GLOBAL, groupList);
 		groups.parallelStream().forEach(group -> {
 			GroupVH groupTemp = new GroupVH(group);
 			String groupName = group.getGroupName();
@@ -3169,7 +3171,7 @@ public class InventoryUtil {
 
 		log.debug(InventoryConstants.ACCOUNT + accountId +" Type : IAM Custom managed policies >> "+policies.size());
 		Map<String,List<Policy>> iamPolicies = new HashMap<>();
-		iamPolicies.put(accountId+delimiter+accountName, policies);
+		iamPolicies.put(accountId + delimiter + accountName + delimiter + REGION_GLOBAL, policies);
 		return iamPolicies;
 	}
 


### PR DESCRIPTION
# Description

- issue: for global assets in aws and azure, the region is populated as null, due to which the region column shows 'No Data' in both assets and violation screen
- root cause: since these assets are global and not specific to a region, we don't get a region for them during collection
- the global asset types are aws_checks(Trusted Advisor Checks), aws_iamrole,aws_iamuser, aws_iampolicies, aws_iamgroup, aws_iamcertificate, aws_account, aws_cloudfront, aws_phd, azure_policydefinitions, azure_securitypricings, azure_subscription
- solution: added region as 'global' for these asset types during collection
- needs plugin change for gcp

Fixes # (issue)
The region for global assets which shows 'No data'

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Run collector for aws and verify region is present in the data files, for the mentioned global asset types.
- [ ] Run collector for azure and verify region is present in the data files, for the mentioned global asset types.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
