### PR TITLE
fix:[CORE-1282] Fix incorrect policy count in asset group selector

### DIFF
--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/AccountsRepository.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/AccountsRepository.java
@@ -87,4 +87,7 @@ public interface AccountsRepository extends JpaRepository<AccountDetails, String
     List<AccountDetails> findByAccountStatusAndPlatform(String accountStatus, String platform);
     List<AccountDetails> findByAccountStatus(String accountStatus);
 
+    @Query("select a from AccountDetails a where a.platform in (select distinct t.dataSourceName from TargetTypes t) and a.accountStatus='configured'")
+    List<AccountDetails> findAllConfiguredAccounts();
+
 }

--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/AzureAccountRepository.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/AzureAccountRepository.java
@@ -18,4 +18,7 @@ public interface AzureAccountRepository extends JpaRepository<AzureAccountDetail
 
     @Query("SELECT distinct subscription from AzureAccountDetails where subscription is NOT NULL ")
     List<String> findSubscriptions();
+
+    @Query("SELECT ac from AzureAccountDetails ac where subscription is NOT NULL and subscriptionStatus='configured'")
+    List<AzureAccountDetails> findConfiguredSubscriptions();
 }


### PR DESCRIPTION
# Description

- issue: policy count includes all cloud providers' policies
- root cause: when an asset group is created by accountId, aliases are added for all cloud types even if the accountId is not relevant to a cloud type. Due to this, based on alias, policies of all cloud types are fetched.
- solution: during assetgroup creation, when assetgroup criteria contains accountId, restrict alias creation to only the cloud type to which the accountId belongs to.
- Jira link: https://paladincloud.atlassian.net/browse/CORE-1282

Fixes # (issue)
Fixes policy count in asset group selector and policies screen

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Create an asset group with aws accountId as a criteria. Verify on assetgroup selector screen and user policies screen, it must display policies related to aws only
- [ ] Create an asset group with two OR criteria aws and gcp accountId. Verify on assetgroup selector screen and user policies screen, it must display policies related to aws and gcp only

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
