### PR TITLE
fix:[CORE-1832] if fre-auto-fix-tran-log index is not created yet and…

### DIFF
--- a/api/pacman-api-statistics/src/main/java/com/tmobile/pacman/api/statistics/repository/StatisticsRepositoryImpl.java
+++ b/api/pacman-api-statistics/src/main/java/com/tmobile/pacman/api/statistics/repository/StatisticsRepositoryImpl.java
@@ -273,8 +273,14 @@ public class StatisticsRepositoryImpl implements StatisticsRepository, Constants
             Gson googleJson = new Gson();
            return googleJson.fromJson(outerBuckets, ArrayList.class); 
         } catch (Exception e) {
-        	LOGGER.error("Error while processing the fre auto fix",e.getMessage());
-        	return new ArrayList<>();
+            /* Index fre-auto-fix-tran-log may not be created until the first autofix is created. In that case, we shall set log level to
+            info and not error because error log will cause data alert to be created. */
+            if (e.getMessage().toLowerCase().endsWith("because not found")) {
+                LOGGER.info("Error while processing the fre auto fix", e.getMessage());
+            } else {
+                LOGGER.error("Error while processing the fre auto fix", e.getMessage());
+            }
+            return new ArrayList<>();
         }
     }
 

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
@@ -682,4 +682,5 @@ public interface PacmanSdkConstants {
     String ACCOUNT_ID = "accountid";
     String TAGGING_MANDATORY_TAGS = "tagging.mandatoryTags";
     String POLICY_NAME = "policyName";
+    String AUTO_FIX_ENABLED = "autoFixEnabled";
 }

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -347,8 +347,8 @@ public class PolicyExecutor {
                 policyEngineStats.putAll(processPolicyEvaluations(resources, evaluations, policyParam,
                         exemptedResourcesForPolicy, individuallyExemptedIssues));
                 try {
-                    if (policyParam.containsKey(PacmanSdkConstants.POLICY_PARAM_AUTO_FIX_KEY_NAME) && Boolean
-                            .parseBoolean(policyParam.get(PacmanSdkConstants.POLICY_PARAM_AUTO_FIX_KEY_NAME))) {
+                    if (policyParam.containsKey(PacmanSdkConstants.AUTO_FIX_ENABLED) && Boolean
+                            .parseBoolean(policyParam.get(PacmanSdkConstants.AUTO_FIX_ENABLED))) {
                         policyEngineStats.putAll(autoFixManager.performAutoFixs(policyParam, exemptedResourcesForPolicy,
                                 individuallyExemptedIssues));
                     }


### PR DESCRIPTION
… statistics api gets exception, then set the log level to info instead of error to avoid creating data alert

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

if fre-auto-fix-tran-log index is not created yet and statistics api gets exception "index_not_found", then set the log level to 'info' instead of error to avoid creating data alert.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
