### PR TITLE
bug:[CORE-1844] admin policy filter changes

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -3092,7 +3092,7 @@ DELETE from pac_v2_ui_options where filterId='10' AND optionName='Event';
 delete from pac_v2_ui_options where filterId=12 and optionValue in ("assets", "violations");
 
 INSERT IGNORE INTO pac_v2_ui_filters (filterId,filterName) VALUES (17,'admin-policy') ON DUPLICATE KEY UPDATE filterName='admin-policy';
-INSERT IGNORE INTO pac_v2_ui_options (filterId,optionName,optionValue,optionURL) VALUES (17,'Policy','policyId','/compliance/v1/filters/policy');
+INSERT IGNORE INTO pac_v2_ui_options (filterId,optionName,optionValue,optionURL) VALUES (17,'Policy','policyDisplayName','/compliance/v1/filters/policy');
 INSERT IGNORE INTO pac_v2_ui_options (filterId,optionName,optionValue,optionURL) VALUES (17,'Asset Type','targetType','/compliance/v1/filters/policy');
 INSERT IGNORE INTO pac_v2_ui_options (filterId,optionName,optionValue,optionURL) VALUES (17,'Severity','severity','/compliance/v1/filters/policy');
 INSERT IGNORE INTO pac_v2_ui_options (filterId,optionName,optionValue,optionURL) VALUES (17,'Category','category','/compliance/v1/filters/policy');


### PR DESCRIPTION
# Description

HOLDING THE PR SINCE WE MAY HAVE A GENERIC SOLUTION FOR THESE ISSUES.
In admin policy, when we fetch the policy column values, we get list of names and id of policy which in case of same name is an ongoing issue in ui. To handle it here, we are going with the approach that backend will return only display name of policy and will take display name in request payload.

![image](https://github.com/PaladinCloud/CE/assets/120437735/9c93af1b-a19b-4000-8763-bdb45a122f85)


Issue :
![image](https://github.com/PaladinCloud/CE/assets/120437735/f969f75c-7c0b-4fcf-a9fc-b4a5f9b73508)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
