### PR TITLE
fix:[CORE-1262] Violation audit logs API must contain exemption info

### DIFF
--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/domain/AuditTrailDTO.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/domain/AuditTrailDTO.java
@@ -1,0 +1,21 @@
+package com.tmobile.pacman.api.compliance.domain;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.Map;
+
+@Value
+@Builder(setterPrefix = "with", toBuilder = true)
+public class AuditTrailDTO {
+
+    String id;
+    String assetGroup;
+    String targetType;
+    String createdBy;
+    String docType;
+    String target;
+    String status;
+    Map<String, Object> parentDetailsMap;
+    Map<String, String> optionalAuditFields;
+}

--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/repository/ComplianceRepositoryImpl.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/repository/ComplianceRepositoryImpl.java
@@ -2232,7 +2232,8 @@ public class ComplianceRepositoryImpl implements ComplianceRepository, Constants
         }
         return urlToQuery;
     }
-    private  String createAuditTrail(String ds, String type, String status, String id,String createdBy, String _type, Map<String, Object> parentDetMap, String target, , Map<String, String> optionalAuditFields) {
+
+    private String createAuditTrail(String ds, String type, String status, String id, String createdBy, String _type, Map<String, Object> parentDetMap, String target, Map<String, String> optionalAuditFields) {
         String date = CommonUtils.getCurrentDateStringWithFormat("UTC","yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         Map<String, Object> auditTrail = new LinkedHashMap<>();
         auditTrail.put("datasource", ds);

--- a/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
+++ b/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
@@ -142,6 +142,7 @@ public interface Constants {
     String ISSUE_RESOURCE_ID = "resourceId";
     String ISSUE_EXCEPTION = "issueException";
     String ISSUE_EXEMPTION_REASON = "exemptionReason";
+    String ISSUE_EXEMPTION_EXPIRY_DATE = "exemptionExpiryDate";
     String DELIMITER_UNDERSCORE = "_";
     String DELIMITER_COMMA = ",";
     String RESOURCE_TYPE = "resourcetType";


### PR DESCRIPTION
# Description

- We want to display the exemption reason and exemption expiry date on violation details screen
- for this, we are adding the exemption reason and exemption expiry date in the /v1/issueauditlog API, so that it can be displayed on UI
- technical detail: on adding an exception, saved the exemption reason and expiry date in the audit logs, so that it can be retrieved along with the audit log that performed it

Fixes # (issue)
Adds exemption detail to audit log in /v1/issueauditlog API

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Call the /v2/issue/add-exception API with appropriate request, in postman
- [ ] verify that /v1/issueauditlog API lists the audit logs with exemption reason and expiry date if present
- [ ] test with adding and revoking multiple exemption for the same violation

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
