### PR TITLE
fix:[UIUX-567] additional dimension of asset type in the asset trend graph

### DIFF
--- a/webapp/src/app/core/services/asset-group-observable.service.ts
+++ b/webapp/src/app/core/services/asset-group-observable.service.ts
@@ -19,7 +19,6 @@
 import { Injectable } from '@angular/core';
 import { Observable ,  ReplaySubject } from 'rxjs';
 import { DataCacheService } from './data-cache.service';
-import { REDHAT, CONTRAST } from 'src/app/shared/constants/global'
 import { AssetTypeMapService } from './asset-type-map.service';
 
 @Injectable()
@@ -27,7 +26,6 @@ import { AssetTypeMapService } from './asset-type-map.service';
 export class AssetGroupObservableService {
 
     private assetGroupSubject = new ReplaySubject<string>(0);
-    private actionDisableSubject = new ReplaySubject<boolean>(0);
 
     private updateTriggerStatus;
 
@@ -45,17 +43,12 @@ export class AssetGroupObservableService {
             this.dataCacheService.setCurrentSelectedAssetGroup(groupName);
             this.assetGroupSubject.next(groupName);
             this.assetTypeMapService.fetchAssetTypesForAg(groupName);
-            this.actionDisableSubject.next([REDHAT, CONTRAST].includes(groupName.toLowerCase()))
             this.updateTriggerStatus = true;
         }
     }
 
     getAssetGroup(): Observable<string> {
         return this.assetGroupSubject.asObservable();
-    }
-
-    isActionDisable(): Observable<boolean> {
-        return this.actionDisableSubject.asObservable();
     }
 
 }

--- a/webapp/src/app/core/services/asset-group-observable.service.ts
+++ b/webapp/src/app/core/services/asset-group-observable.service.ts
@@ -19,17 +19,22 @@
 import { Injectable } from '@angular/core';
 import { Observable ,  ReplaySubject } from 'rxjs';
 import { DataCacheService } from './data-cache.service';
+import { REDHAT, CONTRAST } from 'src/app/shared/constants/global'
+import { AssetTypeMapService } from './asset-type-map.service';
 
 @Injectable()
 
 export class AssetGroupObservableService {
 
-    private subject = new ReplaySubject<string>(0);
+    private assetGroupSubject = new ReplaySubject<string>(0);
+    private actionDisableSubject = new ReplaySubject<boolean>(0);
 
     private updateTriggerStatus;
 
-    constructor(private dataCacheService: DataCacheService) {
-    }
+    constructor(
+        private dataCacheService: DataCacheService,
+        private assetTypeMapService: AssetTypeMapService,
+    ) {}
 
     updateAssetGroup (groupName: string) {
         const previousAssetGroup = this.dataCacheService.getCurrentSelectedAssetGroup();
@@ -38,13 +43,19 @@ export class AssetGroupObservableService {
         // Pass data only when there is valid asset group.
         if (groupName && !shouldNotUpdate) {
             this.dataCacheService.setCurrentSelectedAssetGroup(groupName);
-            this.subject.next(groupName);
+            this.assetGroupSubject.next(groupName);
+            this.assetTypeMapService.fetchAssetTypesForAg(groupName);
+            this.actionDisableSubject.next([REDHAT, CONTRAST].includes(groupName.toLowerCase()))
             this.updateTriggerStatus = true;
         }
     }
 
-    getAssetGroup(): Observable<any> {
-        return this.subject.asObservable();
+    getAssetGroup(): Observable<string> {
+        return this.assetGroupSubject.asObservable();
+    }
+
+    isActionDisable(): Observable<boolean> {
+        return this.actionDisableSubject.asObservable();
     }
 
 }

--- a/webapp/src/app/core/services/asset-type-map.service.ts
+++ b/webapp/src/app/core/services/asset-type-map.service.ts
@@ -1,47 +1,59 @@
- import { Injectable, Inject } from '@angular/core';
- import { HttpService } from '../../shared/services/http-response.service';
- import { ErrorHandlingService } from '../../shared/services/error-handling.service';
- import {environment} from '../../../environments/environment';
-import { Observable, ReplaySubject, Subject } from 'rxjs';
- 
+import { Injectable, Inject } from '@angular/core';
+import { HttpService } from '../../shared/services/http-response.service';
+import { ErrorHandlingService } from '../../shared/services/error-handling.service';
+import {environment} from '../../../environments/environment';
+import { Observable, ReplaySubject} from 'rxjs';
+import { CommonResponseService } from 'src/app/shared/services/common-response.service';
+
 @Injectable({
   providedIn: 'root'
 })
  export class AssetTypeMapService{
-
   private assetTypeMapSubject = new ReplaySubject<Map<string, string>>(0);
+  private assetTypesForAgSubject = new ReplaySubject<Map<string, string>>(0);
 
-    constructor(
-        @Inject(HttpService) private httpService: HttpService,
-                private errorHandlingService: ErrorHandlingService
-    ){
-    }
-    
-    fetchAssetTypes()
-      {
-        const url = environment.getAllAssetTypes.url;
-        const method = environment.getAllAssetTypes.method;
-        const payload = {};
-        try {
-          this.httpService.getHttpResponse(url, method, payload)
-          .subscribe(response =>
-            this.mapData(response))
-        } catch (error) {
-            this.errorHandlingService.handleJavascriptError(error);
-        }
-    }
+  AssetTypesDataForAg
+  constructor(
+    @Inject(HttpService) private httpService: HttpService,
+    private errorHandlingService: ErrorHandlingService,
+    private commonResponseService: CommonResponseService,
+  ){}
 
-    private mapData(assetTypesData){
-      const assetTypeList = assetTypesData.targettypes;
-      const assetTypeMap = new Map<string, string>();
-      assetTypeList.forEach(item => {
-        assetTypeMap.set(item.type, item.displayName);
-      });
-      this.assetTypeMapSubject.next(assetTypeMap);
-    }
-
-    getAssetMap():Observable<any>{
-      return this.assetTypeMapSubject.asObservable();
-    }
-
+  fetchAssetTypes()
+    {
+      const url = environment.getAllAssetTypes.url;
+      const method = environment.getAllAssetTypes.method;
+      try {
+        this.httpService.getHttpResponse(url, method, {})
+        .subscribe(response => this.assetTypeMapSubject.next(this.mapData(response)))
+      } catch (error) {
+          this.errorHandlingService.handleJavascriptError(error);
+      }
   }
+
+  fetchAssetTypesForAg(ag:string) {
+    try {
+      const { url, method } = environment.targetType;
+      this.commonResponseService.getData( url, method, {}, {ag})
+        .subscribe(
+          response => this.assetTypesForAgSubject.next(this.mapData(response)));
+    } catch (error) {
+      this.errorHandlingService.handleJavascriptError(error);
+    }
+  }
+
+  private mapData(data){
+    const {targettypes: types} = data;
+    const assetTypeMap = new Map<string, string>();
+    types.forEach(item => assetTypeMap.set(item.type, item.displayName));
+    return assetTypeMap;
+  }
+
+  getAssetMap():Observable<Map<string, string>>{
+    return this.assetTypeMapSubject.asObservable();
+  }
+
+  getAssetTypeMapForGroup():Observable<Map<string, string>>{
+    return this.assetTypesForAgSubject.asObservable();
+  }
+}

--- a/webapp/src/app/core/services/data-cache.service.ts
+++ b/webapp/src/app/core/services/data-cache.service.ts
@@ -252,15 +252,15 @@ export class DataCacheService {
     return this.get(key);
   }
 
-  public setAssetTrendGraphFiltersList(list) {
-    const key = 'assetTrendGraphFiltersList';
-    return this.set(key,JSON.stringify(list));
+  public setAssetTrendGraphState(data) {
+    const key = 'assetTrendGraphState';
+    return this.set(key,JSON.stringify(data));
   }
 
-  public getAssetTrendGraphFiltersList() {
-    const key = 'assetTrendGraphFiltersList';
-    const list = this.get(key);
-    return list ? JSON.parse(this.get(key)) : undefined;
+  public getAssetTrendGraphState() {
+    const key = 'assetTrendGraphState';
+    const data = this.get(key);
+    return data ? JSON.parse(this.get(key)) : undefined;
   }
 
   /**

--- a/webapp/src/app/core/services/data-cache.service.ts
+++ b/webapp/src/app/core/services/data-cache.service.ts
@@ -252,6 +252,17 @@ export class DataCacheService {
     return this.get(key);
   }
 
+  public setAssetTrendGraphFiltersList(list) {
+    const key = 'assetTrendGraphFiltersList';
+    return this.set(key,JSON.stringify(list));
+  }
+
+  public getAssetTrendGraphFiltersList() {
+    const key = 'assetTrendGraphFiltersList';
+    const list = this.get(key);
+    return list ? JSON.parse(this.get(key)) : undefined;
+  }
+
   /**
    * @author Trinanjan added on 09.04.2018
    * @func setOmniSeachData

--- a/webapp/src/app/pacman-features/modules/assets/asset-dashboard/asset-dashboard.component.css
+++ b/webapp/src/app/pacman-features/modules/assets/asset-dashboard/asset-dashboard.component.css
@@ -19,3 +19,7 @@
 .asset-summary-card {
     flex: 1;
 }
+
+.asset-trend-graph {
+    height: 520px;
+}

--- a/webapp/src/app/pacman-features/modules/assets/asset-dashboard/asset-dashboard.component.html
+++ b/webapp/src/app/pacman-features/modules/assets/asset-dashboard/asset-dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="container-wrapper">
     <div class="asset-dashboard-wrapper flex flex-col">
         <div class="asset-dashboard-header">
-            <app-text classNames="page-title" text="Asset Summary"></app-text>
+            <app-text classNames="page-title" [text]="pageTitle"></app-text>
         </div>
         <div class="type-count-container flex flex-row">
             <app-overview-tile
@@ -11,30 +11,6 @@
                 (navigateTo)="redirectTo($event)"
             ></app-overview-tile>
         </div>
-        <app-custom-card
-            [card]="card"
-            [fromDate]="fromDate"
-            [minDate]="minDate"
-            [selectedItem]="graphInterval"
-            (graphIntervalSelected)="getAssetsCountData($event)"
-            [showDateDropdown]="true"
-        >
-            <div
-                [class.loader]="!totalAssetsCountData.length && totalAssetsCountDataError === ''"
-            ></div>
-            <app-error-message
-                *ngIf="totalAssetsCountDataError"
-                [selectedValue]="totalAssetsCountDataError"
-            ></app-error-message>
-            <app-multiline-zoom-graph
-                *ngIf="totalAssetsCountData.length > 0 && totalAssetsCountDataError === ''"
-                [id]="'TotalAssetsSummaryTrend'"
-                [showLegend]="true"
-                [yAxisLabel]="'Count'"
-                [graphHeight]="graphHeight"
-                [graphLinesData]="totalAssetsCountData"
-            >
-            </app-multiline-zoom-graph>
-        </app-custom-card>
+        <app-asset-trend-graph class="asset-trend-graph"></app-asset-trend-graph>
     </div>
 </div>

--- a/webapp/src/app/pacman-features/modules/compliance/card/card.component.css
+++ b/webapp/src/app/pacman-features/modules/compliance/card/card.component.css
@@ -40,6 +40,10 @@ mat-card-header {
     color: var(--text-high-emphasis);
 }
 
+mat-card-content.asset-graph{
+    padding:0;
+}
+
 mat-card-content {
     display: flex;
     flex-direction: column;
@@ -78,6 +82,10 @@ mat-card-actions button {
     display: flex;
     letter-spacing: -0.005em;
     color: var(--primary-500);
+}
+
+.asset-graph .chart {
+    overflow-y: unset;
 }
 
 .chart {

--- a/webapp/src/app/pacman-features/modules/compliance/card/card.component.html
+++ b/webapp/src/app/pacman-features/modules/compliance/card/card.component.html
@@ -1,33 +1,8 @@
 <mat-card class="panel">
     <mat-card-header>
         {{ card.header }}
-        <div class="graph-dropdown-container" (blur)="test()" *ngIf="card.id === 3">
-            <div class="graph-dropdown-wrapper">
-                <div
-                    class="date-selection-trigger"
-                    #menuTrigger="matMenuTrigger"
-                    [matMenuTriggerFor]="menu"
-                ></div>
-                <app-dropdown
-                    (closeEventEmitter)="onDropdownClose()"
-                    (click)="ifCustomSelected()"
-                    [items]="['1 week', '1 month', '6 months', '12 months', 'All time', 'Custom']"
-                    [selectedItem]="selectedItem"
-                    (selected)="handleGraphIntervalSelection($event)"
-                ></app-dropdown>
-                <mat-menu #menu="matMenu" xPosition="before">
-                    <div class="date-selection-modal">
-                        <app-date-selection
-                            [minDate]="minDate"
-                            [selectedRange]="selectedRange"
-                            (datesSelected)="dateIntervalSelected($event.from, $event.to)"
-                        ></app-date-selection>
-                    </div>
-                </mat-menu>
-            </div>
-        </div>
     </mat-card-header>
-    <mat-card-content>
+    <mat-card-content [ngClass]="{'asset-graph':card.id === 3}">
         <div class="chart" *ngIf="card.id === 1">
             <div [class.loader]="data.length === 0 && dataError === ''"></div>
             <app-error-message *ngIf="dataError" [selectedValue]="dataError"></app-error-message>
@@ -58,18 +33,7 @@
             </div>
         </div>
         <div class="chart" *ngIf="card.id === 3">
-            <div [class.loader]="data.length === 0 && dataError === ''"></div>
-            <app-error-message *ngIf="dataError" [selectedValue]="dataError"></app-error-message>
-            <div class="chart-wrapper" id="TotalAssetsCountTrend">
-                <app-multiline-zoom-graph
-                    *ngIf="data.length > 0 && dataError === ''"
-                    [id]="data[0].info.id"
-                    [showLegend]="data[0].info.showLegend"
-                    [yAxisLabel]="data[0].info.yAxisLabel"
-                    [graphHeight]="data[0].info.height"
-                    [graphLinesData]="data"
-                ></app-multiline-zoom-graph>
-            </div>
+            <app-asset-trend-graph [header]="card.header" [footer]="card.footer"></app-asset-trend-graph>
         </div>
     </mat-card-content>
     <mat-card-actions *ngIf="card.footer">

--- a/webapp/src/app/pacman-features/modules/compliance/card/card.component.html
+++ b/webapp/src/app/pacman-features/modules/compliance/card/card.component.html
@@ -1,5 +1,5 @@
 <mat-card class="panel">
-    <mat-card-header>
+    <mat-card-header *ngIf="card.id !== 3">
         {{ card.header }}
     </mat-card-header>
     <mat-card-content [ngClass]="{'asset-graph':card.id === 3}">

--- a/webapp/src/app/pacman-features/modules/compliance/compliance-dashboard/compliance-dashboard.component.css
+++ b/webapp/src/app/pacman-features/modules/compliance/compliance-dashboard/compliance-dashboard.component.css
@@ -14,7 +14,7 @@
 }
 
 .container-3 {
-    height: 530px;
+    height: 580px;
 }
 
 .container-4 {

--- a/webapp/src/app/pacman-features/modules/compliance/compliance-dashboard/compliance-dashboard.component.html
+++ b/webapp/src/app/pacman-features/modules/compliance/compliance-dashboard/compliance-dashboard.component.html
@@ -64,20 +64,12 @@
         <mat-grid-list
             *ngIf="item === 2"
             [cols]="breakpoint3"
-            rowHeight="530px"
+            rowHeight="580px"
             gutterSize="20px"
             (window:resize)="onresize($event)"
         >
             <mat-grid-tile>
-                <app-card
-                    [card]="cards[2]"
-                    [dataError]="totalAssetsCountDataError"
-                    [data]="totalAssetsCountData"
-                    [fromDate] = "fromDate"
-                    [minDate] = "minDate"
-                    [selectedItem]="graphInterval"
-                    (graphIntervalSelected)="getAssetsCountData($event)"
-                ></app-card>
+                <app-card [card]="cards[2]"></app-card>
             </mat-grid-tile>
         </mat-grid-list>
         <!--./Asset Chart -->

--- a/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.html
+++ b/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.html
@@ -1,0 +1,23 @@
+
+<app-custom-card
+    [card]="card"
+    [fromDate]="fromDate"
+    [minDate]="minDate"
+    [selectedItem]="graphInterval"
+    (graphIntervalSelected)="getAssetsCountData($event)"
+    [showDateDropdown]="true"
+    [filters]="assetTypeFilters"
+    (filterChange)="onFilterChange($event)"
+>   
+    <div [class.loader]="assetsTrendData.length==0 && assetsTrendError==''"></div>
+    <app-multiline-zoom-graph
+        *ngIf="assetsTrendData.length != 0 && assetsTrendError === ''"
+        [id]="'AssetsSummaryTrend'"
+        [showLegend]="true"
+        [yAxisLabel]="'Count'"
+        [graphHeight]="graphHeight"
+        [graphLinesData]="assetsTrendData"
+        [errorMessage]="assetsTrendError"
+    >
+    </app-multiline-zoom-graph>
+</app-custom-card>

--- a/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.html
+++ b/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.html
@@ -8,16 +8,17 @@
     [showDateDropdown]="true"
     [filters]="assetTypeFilters"
     (filterChange)="onFilterChange($event)"
+    (onChipDropdownClose)="onChipDropdownClose()"
 >   
     <div [class.loader]="assetsTrendData.length==0 && assetsTrendError==''"></div>
+    <app-error-message *ngIf="assetsTrendError" [selectedValue]="assetsTrendError"></app-error-message>
     <app-multiline-zoom-graph
-        *ngIf="assetsTrendData.length != 0 && assetsTrendError === ''"
+        *ngIf="assetsTrendData.length !== 0 && assetsTrendError === ''"
         [id]="'AssetsSummaryTrend'"
         [showLegend]="true"
         [yAxisLabel]="'Count'"
         [graphHeight]="graphHeight"
         [graphLinesData]="assetsTrendData"
-        [errorMessage]="assetsTrendError"
     >
     </app-multiline-zoom-graph>
 </app-custom-card>

--- a/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.spec.ts
+++ b/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AssetTrendGraphComponent } from './asset-trend-graph.component';
+
+describe('AssetTrendGraphComponent', () => {
+  let component: AssetTrendGraphComponent;
+  let fixture: ComponentFixture<AssetTrendGraphComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AssetTrendGraphComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AssetTrendGraphComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.ts
+++ b/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.ts
@@ -203,12 +203,12 @@ export class AssetTrendGraphComponent implements OnInit, OnDestroy {
   
 
   // Construct payload for fetching asset trend data
-  private constructPayload(): { ag: string; startDate: string; endDate: string; type?: any } {
+  private constructPayload(): { ag: string; fromDate: string; toDate: string; type?: any } {
     const selectedAssetTypes = this.getSelectedAssetTypes();
     return {
       ag: this.assetGroupName,
-      startDate: this.getFormattedDate(this.fromDate),
-      endDate: this.getFormattedDate(this.toDate),
+      fromDate: this.getFormattedDate(this.fromDate),
+      toDate: this.getFormattedDate(this.toDate),
       type:
         selectedAssetTypes.length !== 0
           ? Object.keys(this.assetTypesList).filter((key) => selectedAssetTypes.includes(this.assetTypesList[key]))

--- a/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.ts
+++ b/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.ts
@@ -1,0 +1,225 @@
+import { Component, OnInit, OnDestroy, Input } from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { AssetGroupObservableService } from 'src/app/core/services/asset-group-observable.service';
+import { AssetTypeMapService } from 'src/app/core/services/asset-type-map.service';
+import {
+  ASSET_TREND,
+  ASSET_TYPE,
+  TOTAL_ASSETS,
+} from 'src/app/shared/constants/asset-trend-graph';
+import { ALL_TIME, API_RESPONSE_ERROR, ERROR } from 'src/app/shared/constants/global';
+import { LoggerService } from 'src/app/shared/services/logger.service';
+import { UtilsService } from 'src/app/shared/services/utils.service';
+import { MultilineChartService } from 'src/app/pacman-features/services/multilinechart.service';
+
+// Interface to define the structure of the AssetTypesFilters object
+interface AssetTypesFilters {
+  list: string[];
+  listData: { [key: string]: boolean };
+  category: string;
+  shortFilters: string[];
+  numberOfAllowedFilters: number;
+}
+
+// Interface to define the structure of the data emitted on filter change
+interface AssetTypeFilterChangeData {
+  category: string;
+  filterName: string;
+  filterValue: boolean;
+}
+
+@Component({
+  selector: 'app-asset-trend-graph',
+  templateUrl: './asset-trend-graph.component.html',
+  styleUrls: ['./asset-trend-graph.component.css'],
+})
+export class AssetTrendGraphComponent implements OnInit, OnDestroy {
+  @Input() header: string = ASSET_TREND;
+
+  // Subject for managing the component lifecycle
+  private destroy$: Subject<void> = new Subject<void>();
+
+  // Private properties
+  private defaultFilterKey = TOTAL_ASSETS;
+  private defaultFilter = {};
+  private assetTypesList;
+  private assetGroupName: string;
+
+  // Public properties
+  public graphInterval = ALL_TIME;
+  public fromDate: Date = new Date(2022, 0, 1);
+  public toDate: Date = new Date();
+  public minDate: Date;
+  public card = {
+    header: this.header,
+  };
+  public graphHeight: number = 360;
+  public filterTitle = ASSET_TYPE;
+  public assetTypeFilters: AssetTypesFilters = {
+    list: [],
+    listData: this.defaultFilter,
+    category: this.filterTitle,
+    shortFilters: [this.defaultFilterKey],
+    numberOfAllowedFilters: 10,
+  };
+  public assetsTrendData = [];
+  public assetsTrendError: string = '';
+
+  constructor(
+    private assetGroupObservableService: AssetGroupObservableService,
+    private assetTypeMapService: AssetTypeMapService,
+    private multilineChartService: MultilineChartService,
+    private utils: UtilsService,
+    private logger: LoggerService
+  ) {}
+
+  ngOnInit(): void {
+    // Initialize default
+    this.defaultFilter[TOTAL_ASSETS] = true;
+    this.card.header = this.header;
+    this.card = { ...this.card };
+    
+    // Subscribe to asset group and asset type map services
+    this.subscribeToAssetGroup();
+    this.subscribeToAssetTypeMapForAG();
+  }
+
+  // Subscribe to asset group changes
+  private subscribeToAssetGroup() {
+    this.assetGroupObservableService
+      .getAssetGroup()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((assetGroupName) => (this.assetGroupName = assetGroupName));
+  }
+
+  // Subscribe to asset type map changes for the asset group
+  private subscribeToAssetTypeMapForAG() {
+    this.assetTypeMapService
+      .getAssetTypeMapForGroup()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((data) => {
+        const list = this.utils.mapValuesToArray(data);
+        this.assetTypesList = this.utils.mapToObject(data);
+        this.assetTypesList.totalassets = TOTAL_ASSETS;
+        this.assetTypeFilters.list = [TOTAL_ASSETS, ...list];
+        this.assetTypeFilters.listData = {
+          ...this.assetTypeFilters.listData,
+          ...Object.fromEntries(list.map((key) => [key, false])),
+        };
+        this.assetTypeFilters = { ...this.assetTypeFilters };
+        this.getAssetsCountData({});
+      });
+  }
+
+  // Handle filter change event
+  public onFilterChange(e: AssetTypeFilterChangeData) {
+    const { filterName, filterValue } = e;
+    this.assetTypeFilters.listData[filterName] = filterValue;
+    this.assetTypeFilters = { ...this.assetTypeFilters };
+    this.getAssetsCountData({});
+  }
+
+  // Fetch asset count data based on selected filters and date interval
+  getAssetsCountData(dateInterval) {
+    if (!this.assetGroupName) {
+      return;
+    }
+    this.assetsTrendError = '';
+    this.assetsTrendData = [];
+
+    const { from, to, graphInterval } = dateInterval;
+
+    this.fromDate = from ? from : new Date(2022, 1, 1);
+    this.toDate = to ? to : new Date();
+    this.graphInterval = graphInterval ? graphInterval : ALL_TIME;
+
+    try {
+      this.multilineChartService
+        .getAssetTrendData(this.constructPayload())
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(
+          (response) => this.updateAssetTrendGraph(response[0]?.data?.trend),
+          (error) => {
+            this.logger.log(ERROR, error);
+            this.assetsTrendError = API_RESPONSE_ERROR;
+          }
+        );
+    } catch (error) {
+      this.assetsTrendError = API_RESPONSE_ERROR;
+      this.logger.log(ERROR, error);
+    }
+  }
+
+  // Construct payload for fetching asset trend data
+  private constructPayload(): { ag: string; startDate: string; endDate: string; type?: any } {
+    const selectedAssetTypes = this.getSelectedAssetTypes();
+
+    return {
+      ag: this.assetGroupName,
+      startDate: this.getFormattedDate(this.fromDate),
+      endDate: this.getFormattedDate(this.toDate),
+      type:
+        selectedAssetTypes.length !== 0
+          ? Object.keys(this.assetTypesList).filter((key) => selectedAssetTypes.includes(this.assetTypesList[key]))
+          : [TOTAL_ASSETS.toLowerCase().replace(/\s/g, '')],
+    };
+  }
+
+  // Get selected asset types based on filters
+  private getSelectedAssetTypes(): string[] {
+    return Object.keys(this.assetTypeFilters.listData).filter((key) => this.assetTypeFilters.listData[key] === true);
+  }
+
+  // Update asset trend graph data for rendering
+  private updateAssetTrendGraph(trendData): void {
+    if (!trendData) {
+      return;
+    }
+    const transformedData = {};
+    trendData.forEach((entry) => {
+      Object.keys(entry).forEach((key) => {
+        if (key !== 'date') {
+          if (!transformedData[key]) {
+            transformedData[key] = {
+              key,
+              values: [],
+            };
+          }
+          transformedData[key].values.push({
+            date: new Date(entry.date),
+            value: entry[key],
+            'zero-value': false,
+            'no-data': false,
+          });
+        }
+      });
+    });
+    const transformedValue = Object.values(transformedData);
+    transformedValue.forEach((item) => (item['key'] = this.assetTypesList[item['key']] || item['key']));
+    this.assetsTrendData = [...transformedValue];
+  }
+
+  // Get minimum date for the date selector
+  getMinDateForDateSelector(dataList) {
+    if (this.graphInterval == ALL_TIME) {
+      if (dataList.length > 0) {
+        this.minDate = new Date(dataList[0].date);
+      } else {
+        this.minDate = new Date();
+      }
+    }
+  }
+
+  // Format date to a string
+  getFormattedDate(date: Date) {
+    const offset = date.getTimezoneOffset();
+    const formattedDate = new Date(date.getTime() - offset * 60 * 1000).toISOString().split('T')[0];
+    return formattedDate;
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.ts
+++ b/webapp/src/app/pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component.ts
@@ -8,13 +8,12 @@ import {
   ASSET_TYPE,
   TOTAL_ASSETS,
 } from 'src/app/shared/constants/asset-trend-graph';
-import { ALL_TIME, API_RESPONSE_ERROR, ERROR } from 'src/app/shared/constants/global';
+import { ALL_TIME, API_RESPONSE_ERROR, ERROR, NO_DATA_AVAILABLE } from 'src/app/shared/constants/global';
 import { LoggerService } from 'src/app/shared/services/logger.service';
 import { UtilsService } from 'src/app/shared/services/utils.service';
 import { MultilineChartService } from 'src/app/pacman-features/services/multilinechart.service';
 import { DataCacheService } from 'src/app/core/services/data-cache.service';
 
-// Interface to define the structure of the AssetTypesFilters object
 interface AssetTypesFilters {
   list: string[];
   listData: { [key: string]: boolean };
@@ -23,11 +22,18 @@ interface AssetTypesFilters {
   numberOfAllowedFilters: number;
 }
 
-// Interface to define the structure of the data emitted on filter change
 interface AssetTypeFilterChangeData {
   category: string;
   filterName: string;
   filterValue: boolean;
+}
+
+type GraphInterval  = 'All time' | '1 week' | '1 month' | '6 months' | '12 months' | 'Custom';
+interface AssetGraphSavedState {
+  assetTypeList: string[];
+  fromDate: Date,
+  toDate: Date,
+  graphInterval: GraphInterval
 }
 
 @Component({
@@ -38,7 +44,6 @@ interface AssetTypeFilterChangeData {
 export class AssetTrendGraphComponent implements OnInit, OnDestroy {
   @Input() header: string = ASSET_TREND;
 
-  // Subject for managing the component lifecycle
   private destroy$: Subject<void> = new Subject<void>();
 
   // Private properties
@@ -46,13 +51,12 @@ export class AssetTrendGraphComponent implements OnInit, OnDestroy {
   private defaultFilter = {};
   private assetTypesList;
   private assetGroupName: string;
-  private savedFilterList:{
-    [key: string]: boolean;
-  };
+  private savedState: AssetGraphSavedState;
+  private defaultFromDate: Date = new Date(2022, 0, 1);
 
   // Public properties
-  public graphInterval = ALL_TIME;
-  public fromDate: Date = new Date(2022, 0, 1);
+  public graphInterval: GraphInterval = ALL_TIME;
+  public fromDate: Date = this.defaultFromDate;
   public toDate: Date = new Date();
   public minDate: Date;
   public card = {
@@ -80,26 +84,11 @@ export class AssetTrendGraphComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    // Initialize saved or default state 
-    this.initializeState();
-    
     // Subscribe to asset group and asset type map services
     this.subscribeToAssetGroup();
     this.subscribeToAssetTypeMapForAG();
   }
-
-  private initializeState(){
-    this.card = { ...{ header:this.header }};
-    const retriveState = this.dataStore.getAssetTrendGraphFiltersList();
-    this.savedFilterList = retriveState ? retriveState : undefined;
-    if(this.savedFilterList){
-      this.assetTypeFilters.listData = this.savedFilterList;
-    }else{
-      this.defaultFilter[TOTAL_ASSETS] = true;
-      this.assetTypeFilters.listData = {...this.assetTypeFilters.listData, ...this.defaultFilter}
-    }
-  }
-
+  
   // Subscribe to asset group changes
   private subscribeToAssetGroup() {
     this.assetGroupObservableService
@@ -107,30 +96,61 @@ export class AssetTrendGraphComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe((assetGroupName) => (this.assetGroupName = assetGroupName));
   }
-
+  
   // Subscribe to asset type map changes for the asset group
   private subscribeToAssetTypeMapForAG() {
     this.assetTypeMapService
       .getAssetTypeMapForGroup()
       .pipe(takeUntil(this.destroy$))
       .subscribe((data) => {
+        if (!data) {
+          this.assetsTrendData = [];
+          this.assetsTrendError = API_RESPONSE_ERROR;
+          return;
+        }
         const list = this.utils.mapValuesToArray(data);
         this.assetTypesList = this.utils.mapToObject(data);
         this.assetTypesList.totalassets = TOTAL_ASSETS;
         this.assetTypeFilters.list = [TOTAL_ASSETS, ...list];
-        if(this.savedFilterList){
-          this.assetTypeFilters.listData = {
-            ...this.assetTypeFilters.listData,
-          };
-        }else{
-          this.assetTypeFilters.listData = {
-            ...this.assetTypeFilters.listData,
-            ...Object.fromEntries(list.map((key) => [key, false])),
-          };
+        this.assetTypeFilters.listData = Object.fromEntries(list.map((key) => [key, false]));
+        this.initializeState();
+        this.assetTypeFilters.listData[TOTAL_ASSETS] = !this.savedState.assetTypeList;
+        if (this.savedState.assetTypeList) {
+          for (const key in this.assetTypeFilters.listData) {
+            if (this.savedState.assetTypeList.includes(key)) {
+              this.assetTypeFilters.listData[key] = true;
+            }
+          }
         }
         this.assetTypeFilters = { ...this.assetTypeFilters };
         this.getAssetsCountData({});
       });
+  }
+
+  private initializeState() {
+    this.card = { ...{ header: this.header }};
+    const retrieveState = this.dataStore.getAssetTrendGraphState();
+    if (!retrieveState) {
+      const { toDate , fromDate, graphInterval} = this;
+      this.savedState = {
+        assetTypeList: undefined,
+        fromDate,
+        toDate,
+        graphInterval
+      }
+      this.assetTypeFilters.listData[TOTAL_ASSETS] = true;
+    } else {
+      const { toDate , fromDate, graphInterval, assetTypeList} = retrieveState;
+      this.savedState = {
+        assetTypeList,
+        fromDate,
+        toDate,
+        graphInterval
+      }
+      this.fromDate = fromDate;
+      this.toDate = toDate;
+      this.graphInterval = graphInterval;
+    }
   }
 
   // Handle filter change event
@@ -146,36 +166,45 @@ export class AssetTrendGraphComponent implements OnInit, OnDestroy {
     if (!this.assetGroupName) {
       return;
     }
+  
     this.assetsTrendError = '';
     this.assetsTrendData = [];
-
-    const { from, to, graphInterval } = dateInterval;
-
-    this.fromDate = from ? from : new Date(2022, 1, 1);
-    this.toDate = to ? to : new Date();
-    this.graphInterval = graphInterval ? graphInterval : ALL_TIME;
-
+  
+    const { from: fromDate, to: toDate, graphInterval } = dateInterval;
+    this.fromDate = fromDate || this.fromDate;
+    this.toDate = toDate || this.toDate;
+  
+    if (graphInterval) {
+      this.graphInterval = graphInterval;
+      if (graphInterval === ALL_TIME) {
+        this.fromDate = this.defaultFromDate;
+      }
+    }
+  
+    this.graphInterval = graphInterval || this.graphInterval;
+  
     try {
       this.multilineChartService
         .getAssetTrendData(this.constructPayload())
         .pipe(takeUntil(this.destroy$))
         .subscribe(
-          (response) => this.updateAssetTrendGraph(response[0]?.data?.trend),
+          (response) => this.updateAssetTrendGraph(response?.[0]?.data?.trend),
           (error) => {
             this.logger.log(ERROR, error);
             this.assetsTrendError = API_RESPONSE_ERROR;
-          }
+          },
+          () => this.storeState()
         );
     } catch (error) {
       this.assetsTrendError = API_RESPONSE_ERROR;
       this.logger.log(ERROR, error);
     }
   }
+  
 
   // Construct payload for fetching asset trend data
   private constructPayload(): { ag: string; startDate: string; endDate: string; type?: any } {
     const selectedAssetTypes = this.getSelectedAssetTypes();
-
     return {
       ag: this.assetGroupName,
       startDate: this.getFormattedDate(this.fromDate),
@@ -195,6 +224,10 @@ export class AssetTrendGraphComponent implements OnInit, OnDestroy {
   // Update asset trend graph data for rendering
   private updateAssetTrendGraph(trendData): void {
     if (!trendData) {
+      return;
+    }
+    if (trendData.length === 0) {
+      this.assetsTrendError = NO_DATA_AVAILABLE;
       return;
     }
     const transformedData = {};
@@ -219,32 +252,37 @@ export class AssetTrendGraphComponent implements OnInit, OnDestroy {
     const transformedValue = Object.values(transformedData);
     transformedValue.forEach((item) => (item['key'] = this.assetTypesList[item['key']] || item['key']));
     this.assetsTrendData = [...transformedValue];
-    this.storeState();
-  }
-
-  // Get minimum date for the date selector
-  getMinDateForDateSelector(dataList) {
-    if (this.graphInterval == ALL_TIME) {
-      if (dataList.length > 0) {
-        this.minDate = new Date(dataList[0].date);
-      } else {
-        this.minDate = new Date();
-      }
-    }
   }
 
   // Format date to a string
   getFormattedDate(date: Date) {
+    if (typeof date === 'string') date = new Date(date);
     const offset = date.getTimezoneOffset();
     const formattedDate = new Date(date.getTime() - offset * 60 * 1000).toISOString().split('T')[0];
     return formattedDate;
   }
 
-  private storeState(){
-    this.dataStore.setAssetTrendGraphFiltersList(this.assetTypeFilters.listData);
+  onChipDropdownClose() {
+    if (this.getSelectedAssetTypes().length === 0) {
+      this.assetTypeFilters.listData[TOTAL_ASSETS] = true;
+      this.assetTypeFilters = { ...this.assetTypeFilters };
+      this.storeState();
+    }
+  }
+
+  private storeState() {
+    const { toDate , fromDate, graphInterval} = this;
+    const state = {
+      assetTypeList: Object.keys(this.assetTypeFilters.listData).filter(key => this.assetTypeFilters.listData[key] === true),
+      toDate,
+      fromDate,
+      graphInterval
+    }
+    this.dataStore.setAssetTrendGraphState(state);
   }
 
   ngOnDestroy(): void {
+    this.storeState();
     this.destroy$.next();
     this.destroy$.complete();
   }

--- a/webapp/src/app/pacman-features/services/multilinechart.service.ts
+++ b/webapp/src/app/pacman-features/services/multilinechart.service.ts
@@ -48,23 +48,19 @@ export class MultilineChartService {
             this.handleError(error);
         }    }
 
-    getAssetTrendData(queryParameters): Observable<any> {
+    getAssetTrendData(payload): Observable<any> {
         const assetTrendUrl = environment.assetTrend.url;
         const method = environment.assetTrend.method;
-        const payload = {};
         try {
             const allObservables: Observable<any>[] = [];
-                const queryParams = {};
                 allObservables.push(
-                    this.httpService.getHttpResponse(assetTrendUrl, method, payload, queryParameters)
-                        // .pipe(map(response => this.massageResponseNew(response))
-                        // .catch(error => this.handleCombiningError(error))
-                // )
+                    this.httpService.getHttpResponse(assetTrendUrl, method, payload, {})
                 );
             return allObservables.length > 0 ? combineLatest(allObservables) : of([]);
         } catch (error) {
             this.handleError(error);
-        }    }
+        }    
+    }
 
     massageResponse(data) {
         const apiResponse = data;

--- a/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.css
+++ b/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.css
@@ -56,6 +56,10 @@ mat-card-header {
   color: var(--text-high-emphasis);
 }
 
+.mat-card-header .title {
+  margin-right: 8px;
+}
+
 mat-card-content {
   display: flex;
   flex-direction: column;

--- a/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.html
+++ b/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.html
@@ -14,6 +14,7 @@
             [appliedFiltersDict]="appliedFiltersDict"
             disableRemoveChip="true"
             (update)="filtersUpdate($event)"
+            (chipDropdownClose)="chipDropdownClose()"
         ></app-table-filter-chip>
         <div *ngIf="showDateDropdown" class="date-dropdown-container">
             <div

--- a/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.html
+++ b/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.html
@@ -1,6 +1,20 @@
 <mat-card class="panel">
     <mat-card-header>
-        {{ card.header }}
+        <span class="title">{{ card.header }}</span>
+        <div *ngIf="tabs">
+            <app-multi-tab-switcher [tabs]="tabs" [tabSelected]="tabSelected" (switchView)="switchTabView($event)"></app-multi-tab-switcher>
+        </div>
+        <app-table-filter-chip
+            *ngIf="filters?.list?.length !== 0 && appliedFiltersDict"
+            [category]="filters.category"
+            [options]="filters.list"
+            [shortFilters]="filters.shortFilters"
+            [numberOfAllowedFilters]="filters.numberOfAllowedFilters"
+            enableMultiValuedFilter="true"
+            [appliedFiltersDict]="appliedFiltersDict"
+            disableRemoveChip="true"
+            (update)="filtersUpdate($event)"
+        ></app-table-filter-chip>
         <div *ngIf="showDateDropdown" class="date-dropdown-container">
             <div
                 class="date-selection-trigger"

--- a/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.html
+++ b/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.html
@@ -5,7 +5,7 @@
             <app-multi-tab-switcher [tabs]="tabs" [tabSelected]="tabSelected" (switchView)="switchTabView($event)"></app-multi-tab-switcher>
         </div>
         <app-table-filter-chip
-            *ngIf="filters?.list?.length !== 0 && appliedFiltersDict"
+            *ngIf="this.showFilters"
             [category]="filters.category"
             [options]="filters.list"
             [shortFilters]="filters.shortFilters"

--- a/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.ts
+++ b/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.ts
@@ -51,6 +51,7 @@ export class CustomCardComponent implements OnInit, OnChanges{
   @ViewChild('menuTrigger') matMenuTrigger: MatMenuTrigger;
   @Output() switchTabs = new EventEmitter<any>();
   @Output() filterChange = new EventEmitter<AssetTypeFilterChangeData>();
+  @Output() onChipDropdownClose =  new EventEmitter();
   agDomainSubscription: Subscription;
   appliedFiltersDict:AppliedFilter | undefined;
 
@@ -61,11 +62,14 @@ export class CustomCardComponent implements OnInit, OnChanges{
     })
    }
 
-  ngOnInit(): void {
-  }
+  ngOnInit(): void {}
 
   ngOnChanges(changes: SimpleChanges) {
-    if(changes?.filters?.currentValue?.listData) this.appliedFiltersDict = {...changes?.filters?.currentValue?.listData}
+    this.appliedFiltersDict = changes?.filters?.currentValue?.listData ?? this.appliedFiltersDict;
+    this.fromDate = changes?.fromDate?.currentValue ?? this.fromDate;
+    this.toDate = changes?.toDate?.currentValue ?? this.toDate;
+    this.minDate = changes?.minDate?.currentValue ?? this.minDate;
+    this.selectedItem = changes?.selectedItem?.currentValue ?? this.selectedItem;
   }
 
   switchTabView($event){
@@ -132,6 +136,10 @@ export class CustomCardComponent implements OnInit, OnChanges{
 
   filtersUpdate(e:AssetTypeFilterChangeData){
     this.filterChange.emit(e);
+  }
+
+  chipDropdownClose(){
+    this.onChipDropdownClose.emit()
   }
 
   ngOnDestroy(){

--- a/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.ts
+++ b/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.ts
@@ -52,8 +52,10 @@ export class CustomCardComponent implements OnInit, OnChanges{
   @Output() switchTabs = new EventEmitter<any>();
   @Output() filterChange = new EventEmitter<AssetTypeFilterChangeData>();
   @Output() onChipDropdownClose =  new EventEmitter();
-  agDomainSubscription: Subscription;
-  appliedFiltersDict:AppliedFilter | undefined;
+  private agDomainSubscription: Subscription;
+  private appliedFiltersDict: AppliedFilter | undefined;
+  showFilters: boolean = false;
+  
 
 
   constructor(private agDomainObservableService:AgDomainObservableService) {
@@ -70,6 +72,7 @@ export class CustomCardComponent implements OnInit, OnChanges{
     if(changes?.toDate?.currentValue) this.toDate = changes?.toDate?.currentValue;
     if(changes?.minDate?.currentValue) this.minDate = changes?.minDate?.currentValue;
     if(changes?.selectedItem?.currentValue) this.selectedItem = changes?.selectedItem?.currentValue;
+    this.updateShowFilters();
   }
 
   switchTabView($event){
@@ -136,6 +139,10 @@ export class CustomCardComponent implements OnInit, OnChanges{
 
   filtersUpdate(e:AssetTypeFilterChangeData){
     this.filterChange.emit(e);
+  }
+
+  private updateShowFilters() {
+    this.showFilters = !!(this.filters?.list?.length !== 0 && this.appliedFiltersDict);
   }
 
   ngOnDestroy(){

--- a/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.ts
+++ b/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.ts
@@ -1,20 +1,43 @@
 
-import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { DateRange } from '@angular/material/datepicker';
 import { MatMenuTrigger } from '@angular/material/menu';
 import { Subscription } from 'rxjs';
 import { AgDomainObservableService } from 'src/app/core/services/ag-domain-observable.service';
+import { ALL_TIME } from 'src/app/shared/constants/global';
+
+interface AssetTypesFilters {
+  list:string[],
+  listData:{
+    [key: string]: boolean;
+  },
+  category:string,
+  shortFilters:string[],
+  numberOfAllowedFilters:number
+}
+
+interface AssetTypeFilterChangeData {
+  category: string;
+  filterName: string;
+  filterValue: boolean;
+}
+
+interface AppliedFilter {
+  [categoryName: string]: boolean
+}
 
 @Component({
   selector: 'app-custom-card',
   templateUrl: './custom-card.component.html',
   styleUrls: ['./custom-card.component.css']
 })
-export class CustomCardComponent implements OnInit {
+export class CustomCardComponent implements OnInit, OnChanges{
 
   @Output() graphIntervalSelected = new EventEmitter();
 
-  @Input() selectedItem = "All time";
+  @Input() tabs;
+  @Input() tabSelected = 0;
+  @Input() selectedItem = ALL_TIME;
   @Input() fromDate: Date;
   @Input() toDate: Date = new Date();
   @Input() minDate: Date = new Date();
@@ -23,10 +46,13 @@ export class CustomCardComponent implements OnInit {
   @Input() card = {
     header: "Default title"
   };
+  @Input() filters: AssetTypesFilters;
   isCustomSelected: boolean = false;
   @ViewChild('menuTrigger') matMenuTrigger: MatMenuTrigger;
   @Output() switchTabs = new EventEmitter<any>();
+  @Output() filterChange = new EventEmitter<AssetTypeFilterChangeData>();
   agDomainSubscription: Subscription;
+  appliedFiltersDict:AppliedFilter | undefined;
 
 
   constructor(private agDomainObservableService:AgDomainObservableService) {
@@ -36,6 +62,14 @@ export class CustomCardComponent implements OnInit {
    }
 
   ngOnInit(): void {
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if(changes?.filters?.currentValue?.listData) this.appliedFiltersDict = {...changes?.filters?.currentValue?.listData}
+  }
+
+  switchTabView($event){
+    this.switchTabs.emit($event);
   }
 
   handleGraphIntervalSelection = (e) => {
@@ -94,6 +128,10 @@ export class CustomCardComponent implements OnInit {
     if(this.selectedItem=="Custom"){
       this.selectedItem = "-1";
     }
+  }
+
+  filtersUpdate(e:AssetTypeFilterChangeData){
+    this.filterChange.emit(e);
   }
 
   ngOnDestroy(){

--- a/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.ts
+++ b/webapp/src/app/shared/components/molecules/custom-card/custom-card.component.ts
@@ -65,11 +65,11 @@ export class CustomCardComponent implements OnInit, OnChanges{
   ngOnInit(): void {}
 
   ngOnChanges(changes: SimpleChanges) {
-    this.appliedFiltersDict = changes?.filters?.currentValue?.listData ?? this.appliedFiltersDict;
-    this.fromDate = changes?.fromDate?.currentValue ?? this.fromDate;
-    this.toDate = changes?.toDate?.currentValue ?? this.toDate;
-    this.minDate = changes?.minDate?.currentValue ?? this.minDate;
-    this.selectedItem = changes?.selectedItem?.currentValue ?? this.selectedItem;
+    if(changes?.filters?.currentValue?.listData) this.appliedFiltersDict = {...changes?.filters?.currentValue?.listData}
+    if(changes?.fromDate?.currentValue) this.fromDate = changes?.fromDate?.currentValue;
+    if(changes?.toDate?.currentValue) this.toDate = changes?.toDate?.currentValue;
+    if(changes?.minDate?.currentValue) this.minDate = changes?.minDate?.currentValue;
+    if(changes?.selectedItem?.currentValue) this.selectedItem = changes?.selectedItem?.currentValue;
   }
 
   switchTabView($event){
@@ -136,10 +136,6 @@ export class CustomCardComponent implements OnInit, OnChanges{
 
   filtersUpdate(e:AssetTypeFilterChangeData){
     this.filterChange.emit(e);
-  }
-
-  chipDropdownClose(){
-    this.onChipDropdownClose.emit()
   }
 
   ngOnDestroy(){

--- a/webapp/src/app/shared/constants/asset-trend-graph.ts
+++ b/webapp/src/app/shared/constants/asset-trend-graph.ts
@@ -1,0 +1,12 @@
+
+export const ASSET_TREND = 'Asset Trend';
+export const TOTAL_ASSETS = 'Total Assets';
+export const ASSET_TYPE = 'Asset Type';
+export const EXEMPT_ASSETS = 'Exempt Assets';
+export const EXEMPT_ASSET_TYPES = 'Exempt Asset Types';
+export const UNTAGGED_ASSETS = 'UnTagged Assets';
+export const TAGGED_ASSETS = 'Tagged Assets';
+
+// Make constants readonly
+Object.freeze(module.exports);
+

--- a/webapp/src/app/shared/constants/global.ts
+++ b/webapp/src/app/shared/constants/global.ts
@@ -1,0 +1,54 @@
+// === Asset Groups ===
+
+export const REDHAT = 'redhat';
+export const CONTRAST = 'contrast';
+
+// === Exception Log Messages ===
+
+export const API_RESPONSE_ERROR = 'apiResponseError';
+export const JS_ERROR = 'jsError';
+export const ERROR = 'error';
+export const NO_DATA_AVAILABLE = 'noDataAvailable'
+
+// === Common Labels ===
+
+export const DEFAULT = 'default';
+export const LEVEL_ZERO = 'level0';
+export const ASSET = 'asset';
+export const CATEGORY = 'category';
+export const POLICY = 'policy';
+export const VIOLATIONS = 'violations';
+export const ASSET_TYPE_SPACE = 'asset type';
+export const COMPLIANCE = 'compliance';
+
+export const ASSET_TYPE_KEY= 'assetType';
+export const ASSETS_LABEL= 'Assets';
+export const POLICIES_LABEL = 'Policies';
+export const CATEGORY_LABEL= 'Category';
+export const COMPLIANT_LABEL = 'Compliant';
+export const COMPLIANCE_LABEL = 'Compliance';
+export const VIOLATIONS_LABEL= 'Violations';
+export const SEVERITY_LABEL= 'Severity';
+export const NON_COMPLIANT_LABEL = 'Non Compliant';
+
+export const SECURITY_LABEL= 'Security';
+export const COST_LABEL= 'Cost';
+export const OPERATIONS_LABEL= 'Operations';
+export const TAGGING_LABEL= 'Tagging';
+
+export const CATEGORY_LIST = [SECURITY_LABEL, COST_LABEL, OPERATIONS_LABEL, TAGGING_LABEL];
+export const SECURITY = 'security';
+export const COST = 'cost';
+export const OPERATIONS = 'operations';
+export const TAGGING = 'tagging';
+
+
+export const TABLE_DIRECTION_ASC = 'asc';
+export const TABLE_DIRECTION_DESC = 'desc';
+
+// === Common Labels for graph ===
+export const ALL_TIME = 'All time';
+
+// Make constants readonly
+Object.freeze(module.exports);
+

--- a/webapp/src/app/shared/constants/global.ts
+++ b/webapp/src/app/shared/constants/global.ts
@@ -1,8 +1,3 @@
-// === Asset Groups ===
-
-export const REDHAT = 'redhat';
-export const CONTRAST = 'contrast';
-
 // === Exception Log Messages ===
 
 export const API_RESPONSE_ERROR = 'apiResponseError';

--- a/webapp/src/app/shared/multiline-zoom-graph/multiline-zoom-graph.component.html
+++ b/webapp/src/app/shared/multiline-zoom-graph/multiline-zoom-graph.component.html
@@ -1,7 +1,7 @@
 <div [class.loader]="graphLinesData.length==0 && errorMessage==''"></div>
 <app-error-message *ngIf="errorMessage"
     [selectedValue]="errorMessage"></app-error-message>
- <div *ngIf="graphLinesData" #graphContainer class="multiline-graph-container" id="{{id}}">
+ <div *ngIf="graphLinesData.length > 0" #graphContainer class="multiline-graph-container" id="{{id}}">
      <div class="flex nowrap-ellipsis gap-16" style="padding: 0px 20px;">
          <ul *ngIf="showLegend" style="flex-grow: 1;" class="flex flex-row nowrap-ellipsis flex-wrap" [class.flex-center]="multiSelectForm.value.length<6">
             <li [title]="line.split('-')[0]" (click)="handleLegendClick(line.split('-')[0])" *ngFor="let line of multiSelectForm.value; let i = index;" class="flex flex-align-center pointer nowrap-ellipsis">

--- a/webapp/src/app/shared/multiline-zoom-graph/multiline-zoom-graph.component.ts
+++ b/webapp/src/app/shared/multiline-zoom-graph/multiline-zoom-graph.component.ts
@@ -313,16 +313,14 @@ export class MultilineZoomGraphComponent implements AfterViewInit, OnChanges {
   ngAfterViewInit(): void {
     setTimeout(() => {
       this.graphWidth = parseInt(window.getComputedStyle(this.graphContainer.nativeElement, null).getPropertyValue('width'), 10);
-      // this.graphHeight = parseInt(window.getComputedStyle(this.graphContainer.nativeElement, null).getPropertyValue('height'), 10) - 70;
       this.init();
-    }, 500);
+    }, 0);
 
     this.windowExpansionService.getExpansionStatus().subscribe((countMap: any) => {
       setTimeout(() => {
       this.graphWidth = parseInt(window.getComputedStyle(this.graphContainer.nativeElement, null).getPropertyValue('width'), 10);
-      // this.graphHeight = parseInt(window.getComputedStyle(this.graphContainer.nativeElement, null).getPropertyValue('height'), 10) - 70;
       this.init();
-      }, 500)
+      }, 0)
     });
   }
 

--- a/webapp/src/app/shared/services/utils.service.ts
+++ b/webapp/src/app/shared/services/utils.service.ts
@@ -526,4 +526,15 @@ export class UtilsService {
       const diffDays = Math.round(Math.abs((date1.getTime() - date2.getTime()) / oneDay));      
       return diffDays;
     }
+
+    mapToObject(map: Map<string, string> | undefined): { [key: string]: string } | undefined {
+      return map
+        ? Object.fromEntries(map)
+        : undefined;
+    }
+
+    mapValuesToArray(map):string[] {
+      if(map) return Array.from(map.values());
+      else return undefined;
+    }
 }

--- a/webapp/src/app/shared/shared.module.ts
+++ b/webapp/src/app/shared/shared.module.ts
@@ -128,6 +128,7 @@ import { WidgetSectionStarterComponent } from './widget-section-starter/widget-s
 import {ClipboardModule} from '@angular/cdk/clipboard';
 import { IssueFilterService } from '../pacman-features/services/issue-filter.service';
 import { DateRangeFormatterPipe } from './table-filters/pipes/date-range-formatter.pipe';
+import { AssetTrendGraphComponent } from '../pacman-features/secondary-components/asset-trend-graph/asset-trend-graph.component';
 
 @NgModule({
     imports: [
@@ -235,7 +236,8 @@ import { DateRangeFormatterPipe } from './table-filters/pipes/date-range-formatt
         ToastNotificationComponent,
         WidgetSectionStarterComponent,
         CellDataCasePipe,
-        DateRangeFormatterPipe
+        DateRangeFormatterPipe,
+        AssetTrendGraphComponent
     ],
     exports: [
         CellDataCasePipe,
@@ -317,6 +319,7 @@ import { DateRangeFormatterPipe } from './table-filters/pipes/date-range-formatt
         TitleBurgerHeadComponent,
         ToastNotificationComponent,
         WidgetSectionStarterComponent,
+        AssetTrendGraphComponent
     ],
     providers: [
         IssueFilterService,

--- a/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.css
+++ b/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.css
@@ -44,8 +44,9 @@
 }
 
 .filters-chip-menu .fcm-item {
-    padding: 10px 12px 10px 20px;
+    padding: 6px 8px 6px 16px;
     color: #272e35;
+    margin: 4px;
 }
 
 .filters-chip-menu .fcm-item:hover {

--- a/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.css
+++ b/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.css
@@ -44,9 +44,8 @@
 }
 
 .filters-chip-menu .fcm-item {
-    padding: 6px 8px 6px 16px;
+    padding: 10px 12px 10px 20px;
     color: #272e35;
-    margin: 4px;
 }
 
 .filters-chip-menu .fcm-item:hover {

--- a/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.css
+++ b/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.css
@@ -81,6 +81,7 @@
     flex: 1 0 0;
     background-color: #FEF5F5;
     border-top: 1px solid #fccfcf;
+    border-radius: 0 0 6px 6px;
     font-family: 'mark-pro-medium';
 }
 
@@ -99,4 +100,8 @@
     font-weight: 500;
     line-height: 16px;
     letter-spacing: 0.1px;
+}
+
+.mat-checkbox-disabled {
+    cursor: not-allowed;
 }

--- a/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.css
+++ b/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.css
@@ -28,7 +28,7 @@
 }
 
 .filters-menu-container {
-    max-height: 336px;
+    max-height: 345px;
     background: white;
     border: 1px solid rgba(16 40 72 / 9%);
     border-radius: 6px;
@@ -46,14 +46,57 @@
 .filters-chip-menu .fcm-item {
     padding: 6px 8px 6px 16px;
     color: #272e35;
+    margin: 4px;
 }
 
 .filters-chip-menu .fcm-item:hover {
     cursor: pointer;
     background: rgba(2 47 82 / 6%);
+    border-radius: 6px;
 }
 
 .disabled {
     background-color: var(--color-neutral-p6);
     border: 1px solid var(--color-neutral-p3);
+}
+
+.selected {
+    background: rgba(2 47 82 / 6%);
+    border-radius: 6px;
+}
+
+.info-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    align-self: stretch;
+    border-top: 2px solid var(--Border-Default-Alpha, rgba(16, 40, 72, 0.09));
+}
+
+.info-wrapper {
+    display: flex;
+    padding: 16px;
+    align-items: center;
+    gap: 8px;
+    flex: 1 0 0;
+    background-color: #FEF5F5;
+    border-top: 1px solid #fccfcf;
+    font-family: 'mark-pro-medium';
+}
+
+.info-wrapper img {
+    display: flex;
+    width: 16px;
+    height: 16px;
+}
+
+.info-label {
+    align-self: stretch;
+    color: var(--Content-Tertiary, #586470);
+    font-feature-settings: 'clig' off, 'liga' off;
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 16px;
+    letter-spacing: 0.1px;
 }

--- a/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.html
+++ b/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.html
@@ -25,7 +25,7 @@
             <ng-template #moreFilters> {{ appliedFilters.length }} Selected </ng-template>
         </span>
     </div>
-    <mat-icon class="tfc-close-icon" (click)="clear.emit(category)">close</mat-icon>
+    <mat-icon *ngIf="!disableRemoveChip" class="tfc-close-icon" (click)="clear.emit(category)">close</mat-icon>
 </div>
 
 <ng-template
@@ -39,17 +39,26 @@
     <div class="filters-menu-container flex flex-col" *ngIf="isOptionsMenuOpen && !isDateFilter">
         <app-table-filter-search [(text)]="optionFilterQuery" (textChange)="handleSearchTextChange($event)"></app-table-filter-search>
         <ul class="filters-chip-menu">
-            <li *ngFor="let option of filteredOptions" class="fcm-item" [title]="option">
+            <li 
+                *ngFor="let option of filteredOptions" 
+                ngClass="appliedFiltersDict[option]" [ngClass]="{'selected': appliedFiltersDict[option]}" [ngClass]="{'cursor-not-allowed':isDisableFilters && !appliedFiltersDict[option]}" class="fcm-item" [title]="option">
                 <mat-checkbox
                     color="primary"
                     [checked]="appliedFiltersDict[option]"
                     (change)="updateFilterOption(option, $event.checked)"
+                    [disabled]="isDisableFilters && !appliedFiltersDict[option]"
                 >
                     <span *ngIf="!filtersToExcludeFromCasing.includes(category)">{{ option | slice : 0 : maxOptionChars | celldatacase }}</span>
                     <span *ngIf="filtersToExcludeFromCasing.includes(category)">{{ option | slice : 0 : maxOptionChars }}</span>
                 </mat-checkbox>
             </li>
         </ul>
+        <div *ngIf="isDisableFilters" class="info-container">
+            <div class="info-wrapper">
+                <img src="/assets/icons/info-circle-chip.svg" />
+                <div class="info-label">You can only select {{numberOfAllowedFilters}} asset types for comparison</div>
+            </div>
+        </div>
     </div>
     <ng-container *ngIf="isOptionsMenuOpen && isDateFilter">
         <div class="date-selection-modal">

--- a/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.ts
+++ b/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.ts
@@ -44,6 +44,7 @@ export class TableFilterChipComponent implements OnInit, OnChanges {
     @Output() clear = new EventEmitter<string>();
     @Output() update = new EventEmitter<FilterChipUpdateEvent>();
     @Output() filterSearchTextChange = new EventEmitter();
+    @Output() chipDropdownClose = new EventEmitter();
 
     readonly optionsMenuOffsetY = 7;
     readonly maxOptionChars = 30;
@@ -101,6 +102,7 @@ export class TableFilterChipComponent implements OnInit, OnChanges {
     closeMenu(){
         this.isOptionsMenuOpen = false;
         this.optionFilterQuery = '';
+        this.chipDropdownClose.emit(null);
     }
 
     sortCheckedOptionsFirst(){

--- a/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.ts
+++ b/webapp/src/app/shared/table-filters/table-filter-chip/table-filter-chip.component.ts
@@ -14,10 +14,13 @@ export interface FilterChipUpdateEvent {
 })
 export class TableFilterChipComponent implements OnInit, OnChanges {
     @Input() isDisabled = false;
+    @Input() disableRemoveChip = false;
     @Input() filtersToExcludeFromCasing = [];
     @Input() category: string;
     @Input() options: string[] = [];
     @Input() dateCategoryList: string[] = [];
+    @Input() shortFilters: string[] = [];
+    @Input() numberOfAllowedFilters:number;
     isDateFilter: boolean = false;
     calendarMinDate: Date;
     calendarMaxDate: Date;
@@ -49,6 +52,7 @@ export class TableFilterChipComponent implements OnInit, OnChanges {
 
     optionFilterQuery = '';
     filteredOptions = [];
+    isDisableFilters = false;
 
     private _appliedFilters: { name: string; value: boolean }[] = [];
     private _appliedFiltersDict: { [key: string]: boolean } = {};
@@ -67,6 +71,9 @@ export class TableFilterChipComponent implements OnInit, OnChanges {
                 this.calendarMaxDate = new Date(this.options[1]);
             }
             this.filterOptionsByQuery();
+        }
+        if(changes.appliedFiltersDict){
+            this.isMaxfiltersSelected();
         }
     }
 
@@ -97,9 +104,15 @@ export class TableFilterChipComponent implements OnInit, OnChanges {
     }
 
     sortCheckedOptionsFirst(){
-        const checkedOptions = Object.keys(this.appliedFiltersDict || {}).filter(key => this.appliedFiltersDict[key]);
-        const uncheckedOptions = this.options?.filter((f) => !checkedOptions.includes(f)) || [];
-        this.options = [...checkedOptions, ...uncheckedOptions];
+        let checkedOptions = Object.keys(this.appliedFiltersDict || {}).filter(key => this.appliedFiltersDict[key]);
+        let uncheckedOptions = this.options?.filter((f) => !checkedOptions.includes(f)) || [];
+        if(this.shortFilters?.length === 0){
+            this.options = [...checkedOptions, ...uncheckedOptions];
+        }else{
+            checkedOptions = checkedOptions.filter(item => !this.shortFilters.includes(item));
+            uncheckedOptions = uncheckedOptions.filter(item => !this.shortFilters.includes(item));
+            this.options = [...this.shortFilters, ...checkedOptions, ...uncheckedOptions];
+        }
     }
 
     dateIntervalSelected(from?, to?){
@@ -137,6 +150,14 @@ export class TableFilterChipComponent implements OnInit, OnChanges {
             }catch(e){
                 this.logger.log('jsError', e);
             }
+        }
+    }
+
+    isMaxfiltersSelected(){
+        if(this.numberOfAllowedFilters && Object.values(this.appliedFiltersDict).filter(value => value).length >=this.numberOfAllowedFilters){
+            this.isDisableFilters = true;
+        }else{
+            this.isDisableFilters = false;
         }
     }
 }

--- a/webapp/src/app/shared/table-filters/table-filters.component.css
+++ b/webapp/src/app/shared/table-filters/table-filters.component.css
@@ -48,11 +48,18 @@
 .filters-category-menu .fcm-item {
     padding: 6px 8px 6px 16px;
     color: #272e35;
+    margin: 4px;
 }
 
 .filters-category-menu .fcm-item:hover {
     cursor: pointer;
     background: rgba(2 47 82 / 6%);
+    border-radius: 6px;
+}
+
+.filters-category-menu .selected {
+    background: rgba(2 47 82 / 6%);
+    border-radius: 6px;
 }
 
 .btn-disabled{

--- a/webapp/src/app/shared/table-filters/table-filters.component.html
+++ b/webapp/src/app/shared/table-filters/table-filters.component.html
@@ -57,6 +57,7 @@
                     *ngFor="let option of filterSelectedCategoryOptionsByQuery()"
                     class="fcm-item"
                     [title]="option"
+                    [ngClass]="{'selected': appliedFiltersDict[selectedCategory!][option]}"
                 >
                     <mat-checkbox
                         [checked]="appliedFiltersDict[selectedCategory!][option]"

--- a/webapp/src/assets/icons/info-circle-chip.svg
+++ b/webapp/src/assets/icons/info-circle-chip.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_852_18225)">
+<path d="M7.99967 10.6663V7.99967M7.99967 5.33301H8.00634M14.6663 7.99967C14.6663 11.6816 11.6816 14.6663 7.99967 14.6663C4.31778 14.6663 1.33301 11.6816 1.33301 7.99967C1.33301 4.31778 4.31778 1.33301 7.99967 1.33301C11.6816 1.33301 14.6663 4.31778 14.6663 7.99967Z" stroke="#F26464" stroke-width="1.33" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_852_18225">
+<rect width="16" height="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/webapp/src/environments/environment.prod.ts
+++ b/webapp/src/environments/environment.prod.ts
@@ -215,7 +215,7 @@
     },
     assetTrend: {
         url: '{{baseUrl}}/asset/v1/trend/assetcount',
-        method: 'GET'
+        method: 'POST'
     },
     resourceCount: {
         url: '{{baseUrl}}/asset/v1/count',

--- a/webapp/src/environments/environment.stg.ts
+++ b/webapp/src/environments/environment.stg.ts
@@ -215,7 +215,7 @@
     },
     assetTrend: {
         url: '{{baseUrl}}/asset/v1/trend/assetcount',
-        method: 'GET'
+        method: 'POST'
     },
     resourceCount: {
         url: '{{baseUrl}}/asset/v1/count',

--- a/webapp/src/environments/environment.ts
+++ b/webapp/src/environments/environment.ts
@@ -215,7 +215,7 @@
     },
     assetTrend: {
         url: '{{baseUrl}}/asset/v1/trend/assetcount',
-        method: 'GET'
+        method: 'POST'
     },
     resourceCount: {
         url: '{{baseUrl}}/asset/v1/count',


### PR DESCRIPTION
# Description

At present, we only display the general trend for assets without providing details on the specific asset types. Given that the necessary data is available in the backend, it would be valuable to incorporate insights into the distinct asset types within the same graph.

https://paladincloud.atlassian.net/browse/UIUX-567

Fixes # (issue)

- Developed a shared component for visualising asset trends, incorporating an asset type filter. 
- Common component was then implemented in both the asset graph on the dashboard and the asset summary section.
- Code streamlined, eliminating redundancy.
- Please review the attached video to observe and reference the behaviour 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

https://github.com/PaladinCloud/CE/assets/152586069/6197e7b7-0bc4-428c-8781-f1dd23598802


