### PR TITLE
fix:[CORE-1860] update /trend/assetcount api to return asset count of all assets and individual asset types together

### DIFF
--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/controller/AssetTrendController.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/controller/AssetTrendController.java
@@ -110,6 +110,11 @@ public class AssetTrendController {
                     return ResponseUtils.buildFailureResponse(new Exception("Attribute 'type' should be a List."));
                 }
                 type = (List<String>) requestPayload.get("type");
+                if (type.isEmpty()) {
+                    return ResponseUtils.buildFailureResponse(new Exception("Attribute 'type' cannot be empty."));
+                }
+            } else {
+                return ResponseUtils.buildFailureResponse(new Exception("Attribute 'type' is not provided."));
             }
             Map<String, Object> response = new LinkedHashMap<>();
             response.put("ag", assetGroup);

--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/repository/AssetRepository.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/repository/AssetRepository.java
@@ -576,7 +576,7 @@ public interface AssetRepository {
      */
     public List<String> getProvidersForAssetGroup(String assetGroup) throws DataException;
 
-    public List<Map<String, Object>> getAssetCountTrend(String assetGroup, String type, Date from, Date to);
+    public List<Map<String, Object>> getAssetCountTrend(String assetGroup, List<String> type, String from, String to);
 
     public Set<String> getMandatoryTags(String serviceName);
 

--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/service/AssetService.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/service/AssetService.java
@@ -531,7 +531,7 @@ public interface AssetService {
      */
 	public List<String> getProvidersForAssetGroup(String assetGroup) throws DataException;
 
-    public List<Map<String, Object>> getAssetCountTrend(String assetGroup, String type, Date from, Date to);
+    public List<Map<String, Object>> getAssetCountTrend(String assetGroup, List<String> type, String from, String to);
 
     public Set<String> getMandatoryTags(String filterName);
 

--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/service/AssetServiceImpl.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/service/AssetServiceImpl.java
@@ -1199,7 +1199,7 @@ public class AssetServiceImpl implements AssetService {
     }
 
     @Override
-    public List<Map<String, Object>> getAssetCountTrend(String assetGroup, String type, Date from, Date to) {
+    public List<Map<String, Object>> getAssetCountTrend(String assetGroup, List<String> type, String from, String to) {
         return repository.getAssetCountTrend(assetGroup, type, from, to);
     }
 

--- a/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
+++ b/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
@@ -555,4 +555,7 @@ public interface Constants {
     String TENABLE_API_URL = "https://cloud.tenable.com";
     String GROUP_NAME_FOR_ALL_SOURCES_ASSET_GROUP = "all-sources";
     String TOTAL_VIOLATIONS = "totalViolations";
+    String DOCID_KEYWORD_FIELD_NAME =  "_docid.keyword";
+    String ASSET = "asset";
+    String TOTAL_ASSETS = "totalassets";
 }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.


1.  If user provides 'totalassets' along with other asset types in the payload of api /trend/assetcount (trend graph api), then api should return total assets and assets for each provided asset type in the response. Earlier, api used to return data either for totalassets or individual asset types. Now with these changes, api will simultaneously return both as shown in the below image.

![oss_assettrend](https://github.com/PaladinCloud/CE/assets/84776630/4f4458e8-bdf8-4f14-a17f-2b822391e758)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
