### PR TITLE
fix:[CORE-1843] Added isVisible check

### DIFF
--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/repository/AssetRepositoryImpl.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/repository/AssetRepositoryImpl.java
@@ -773,8 +773,8 @@ public class AssetRepositoryImpl implements AssetRepository {
 			ListIterator<String> iterator = recentViewList.listIterator(recentViewList.size());
 			while (iterator.hasPrevious()) {
 				String ag = iterator.previous();
-				String query = "SELECT displayName FROM cf_AssetGroupDetails WHERE groupName = '" + ag + "'";
-				String displayName = rdsRepository.queryForString(query);
+                String query = "SELECT displayName FROM cf_AssetGroupDetails WHERE groupName = '" + ag + "'" + " and isVisible is true";
+                String displayName = rdsRepository.queryForString(query);
 				if (displayName != null) {
 					Map<String, Object> details = Maps.newHashMap();
 					details.put("ag", ag);


### PR DESCRIPTION
# Description

There is some state data in recently viewed asset groups data for some tenants. That happened due to a bug while delivering the Red Hat plugin. Though we fixed that bug, some tenants have the data populated in the recently viewed asset groups table.

The stale data is causing issues when the plugin is unavailable in the system. Added a check in the API to avoid the issue.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the API locally and it is not throwing any errors.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code

# **Other information**:

List any documentation updates that are needed for the Wiki
