### PR TITLE
fix:[CORE-1856] remove call to obsolete indices like cpu_utilization …

### DIFF
--- a/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/controller/AssetDetailController.java
+++ b/api/pacman-api-asset/src/main/java/com/tmobile/pacman/api/asset/controller/AssetDetailController.java
@@ -468,33 +468,24 @@ public class AssetDetailController {
                 Util.encodeUrl(resourceId), ag, resourceType);
 
         Map<String, Object> assetSummary = new HashMap<>();
-
         try {
-
             List<Map<String, Object>> attributesList = new ArrayList<>();
-
             Map<String, Object> attribute = new LinkedHashMap<>();
             attribute.put(Constants.NAME, "resourceId");
             attribute.put(Constants.VALUE, resourceId);
             attributesList.add(attribute);
-
             attribute = new LinkedHashMap<>();
             attribute.put(Constants.NAME, "Overall Compliance");
             attribute.put(Constants.VALUE, violationSummary.getData().getCompliance());
             attributesList.add(attribute);
-
             if (Constants.EC2.equals(resourceType)) {
                 attribute = new LinkedHashMap<>();
                 attribute.put(Constants.NAME, "statename");
                 attribute.put(Constants.VALUE, assetService.getEc2StateDetail(ag, resourceId));
                 attributesList.add(attribute);
-
-                attributesList.add(getAverageCPUUtilization(resourceId));
             }
-
             assetSummary.put("resourceId", resourceId);
             assetSummary.put("attributes", attributesList);
-
         } catch (Exception e) {
             LOGGER.error("Error in getEc2ResourceSummary",e);
             assetSummary = new HashMap<>();

--- a/api/pacman-api-statistics/src/main/java/com/tmobile/pacman/api/statistics/service/StatisticsServiceImpl.java
+++ b/api/pacman-api-statistics/src/main/java/com/tmobile/pacman/api/statistics/service/StatisticsServiceImpl.java
@@ -199,7 +199,6 @@ public class StatisticsServiceImpl implements StatisticsService, Constants {
             Map<String, Object> data = new HashMap<>();
             data.put("totalAutoFixesApplied", getAutofixStats().get(0).get(COUNT));
             Long totalAssets = getTotalAssetCount();
-            Long eventsProcessed = getTotalEventProcessed();
             Map<String, Long> violationsMap = getIssueDistribution();
             String targettypes = repository.getTargetTypeForAG(MASTER_ALIAS, null);
             ExecutorService executor = Executors.newCachedThreadPool();
@@ -237,11 +236,9 @@ public class StatisticsServiceImpl implements StatisticsService, Constants {
             data.put("numberOfAwsAccounts", totalAccounts);
             // 3.Total Assets Scanned
             data.put("totalNumberOfAssets", totalAssets);
-            // 4.Total Events Processed
-            data.put("numberOfEventsProcessed", eventsProcessed);
-            // 5. No of polices Evaluated from Fre-stats
+            // 4. No of polices Evaluated from Fre-stats
             data.put("numberOfPolicyEvaluations", numberOfPolicyEvaluations);
-            // 6. Auto Fix
+            // 5. Auto Fix
             data.put("numberOfPolicyWithAutoFixesAvailable", numberOfPolicyWithAutoFixesAvailable);
             data.put("numberOfPolicyWithAutoFixesEnabled", numberOfPolicyWithAutoFixesEnabled);
 


### PR DESCRIPTION
…and blackbox in apis

# Description

Asset details api is trying to query an obsolete ES index 'cpu_utilization' for ec2 assets which is causing ES exception and data alert is created. Similarly statistics api is querying blackbox index which is obsolete presently. Removing calls to these methods which are causing dataalerts. 

![assetdetails_summary](https://github.com/PaladinCloud/CE/assets/84776630/52805bd6-a269-4f0c-9e9a-001119edc8c2)
![statsapi](https://github.com/PaladinCloud/CE/assets/84776630/bc6f5447-fa44-4f96-accb-b18e2a6a2cd1)



Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# **Other information**:

List any documentation updates that are needed for the Wiki
