### PR TITLE
fix:[CORE-1771] Get the target types from db for asset group creation screen

### DIFF
--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/TargetTypesRepository.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/TargetTypesRepository.java
@@ -71,4 +71,7 @@ public interface TargetTypesRepository extends JpaRepository<TargetTypes, String
 	@Query("SELECT DISTINCT dataSourceName FROM TargetTypes")
 	public Optional<List<String>> findDistinctDataSources();
 
+	@Query("SELECT DISTINCT targetName FROM TargetTypes WHERE dataSourceName = :dataSource AND status not in ('disabled','finding')")
+	public List<String> findValidTypesByDataSource(@Param("dataSource") String dataSource);
+
 }

--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupServiceImpl.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupServiceImpl.java
@@ -794,14 +794,7 @@ public class AssetGroupServiceImpl implements AssetGroupService {
 				JsonObject responseJson = parser.parse(responseDetails).getAsJsonObject();
 				JsonObject aggs = (JsonObject) responseJson.get("aggregations");
 
-				List<String> targetTypes = new ArrayList<>();
-				JsonObject targetTypeObj = (JsonObject) aggs.get("TargetType");
-				JsonArray targetTypeBuckets = targetTypeObj.get(BUCKETS).getAsJsonArray();
-				for (JsonElement bucket : targetTypeBuckets) {
-					targetTypes.add(bucket.getAsJsonObject().get(KEY).getAsString());
-				}
-				cloudTypeObject.put("TargetType", targetTypes);
-
+				cloudTypeObject.put("TargetType", targetTypesRepository.findValidTypesByDataSource(cloudType));
 
 				List<String> regions = new ArrayList<>();
 				JsonObject regionObj = (JsonObject) aggs.get("Region");

--- a/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/repo/ElasticSearchRepository.java
+++ b/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/repo/ElasticSearchRepository.java
@@ -1950,7 +1950,6 @@ public class ElasticSearchRepository implements Constants {
 		String body = "{"
 				+ "\"query\":{\"bool\":{\"must\":[{\"term\":{\"latest\":\"true\"}},{\"term\":{\"_entity\":\"true\"}}]}}"
 				+ ",\"aggs\": {"
-				+ "\"TargetType\": {\"terms\": {\"field\": \"docType.keyword\",\"size\":"+ES_PAGE_SIZE+"}},"
 				+ "\"Id\": {\"terms\": {\"field\": \"" + accountId +".keyword\",\"size\":"+ES_PAGE_SIZE+"}},"
 				+ "\"Region\": {\"terms\": {\"field\": \"region.keyword\",\"size\": "+ES_PAGE_SIZE+"}},";
 


### PR DESCRIPTION
## Description

- Issue: when an asset group is created with a certain asset type and later the account doesn't have an asset of that asset type and the "Edit asset group" screen shows blank for that asset type
- cause: this is because the list of asset types are fetched from the ES data which only stores the assets that are currently active and hence when the asset is no longer in the account, it is not included in the list of asset types displayed on the asset group creation/edit screen
- fix: getting the list of asset types from cf_Target table which will always return all the asset types valid for cloud types irrespective of if the cloud account has an active asset
- get the valid assets only with status enabled or active

### Problem
this is because the list of asset types are fetched from the ES data which only stores the assets that are currently active and hence when the asset is no longer in the account, it is not included in the list of asset types displayed on the asset group creation/edit screen

### Solution
getting the list of asset types from cf_Target table which will always return all the asset types valid for cloud types irrespective of if the cloud account has an active asset

## Fixes # (issue if any)
asset group edit screen

## Type of change

**Please delete options that are not relevant.**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] create an asset group with target type as criteria
- [ ] delete that particular asset in the aws account(can also make latest=false)
- [ ] verify the edit asset group screen, the target type must be blank 
- [ ] after fix, in step 3, the target type is not blank since the list of asset types are taken from cf_Target table

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
