### PR TITLE
feat:[CORE-1653] Standardize asset display names which are same for different sources

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -3268,3 +3268,12 @@ DELIMITER ;
 CALL update_asset_group_dates_to_use_timestamp();
 
 INSERT IGNORE INTO pac_v2_ui_options (filterId,optionName,optionValue,optionURL) VALUES (1,'Source','pac_ds.keyword','/compliance/v1/filters/attribute');
+
+UPDATE cf_Target SET displayName='Load Balancer' WHERE targetName in ('gcploadbalancer','loadbalancer');
+UPDATE cf_Target SET displayName='Managed Disk' WHERE targetName in ('gcpdisks','disk');
+UPDATE cf_Target SET displayName='MySQL Server' WHERE targetName in ('cloudsql_mysqlserver','mysqlserver');
+UPDATE cf_Target SET displayName='SQL Server' WHERE targetName in ('cloudsql_sqlserver','sqlserver');
+UPDATE cf_Target SET displayName='IAM User' WHERE targetName in ('iamuser','iamusers');
+UPDATE cf_Target SET displayName='KMS Key' WHERE targetName in ('kms','kmskey');
+UPDATE cf_Target SET displayName='Subnet' WHERE targetName in ('subnet','subnets');
+UPDATE cf_Target SET displayName='VM' WHERE targetName in ('virtualmachine','vminstance');


### PR DESCRIPTION
## Description

- different cloud providers have assetTypes that have similar name and those are displayed on UI with (cloudtType) as suffix.
- we are removing the cloudType suffix for the assetTypes with same names, so that the assets of multiple cloud sources can be selected with a common display name.

### Problem
different cloud providers have assetTypes that have similar name and those are displayed on UI with (cloudtType) as suffix

### Solution
- remove the suffixed cloud provider name for the colliding asset names in cf_Target table, so that they are displayed under single name in Ui
- rename the taegetTypeDisplayName in ES to remove the suffix(ES script attached in the ticket)

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] run the sql script to update the display names of assets
- [x] run the ES queries attached in the jira ticket
- [x] verify that the asset names are displayed on UI without the suffix

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
