### PR TITLE
fix:[CORE-1879] create default region as us-east-1 for sdk client in policy rule

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/misc/CheckAWSConfigEnabled.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/misc/CheckAWSConfigEnabled.java
@@ -24,6 +24,7 @@ package com.tmobile.cloud.awsrules.misc;
 
 import java.util.*;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -77,8 +78,12 @@ public class CheckAWSConfigEnabled extends BasePolicy {
 		String category = ruleParam.get(PacmanRuleConstants.CATEGORY);
 		String defaultRegion=ruleParam.get("defaultRegion");
 
-		Map<String ,String> localRuleParam=new HashMap<>(ruleParam);
-		localRuleParam.putIfAbsent(PacmanRuleConstants.REGION, defaultRegion);
+		Map<String, String> localRuleParam = new HashMap<>(ruleParam);
+		if (StringUtils.isBlank(localRuleParam.get(PacmanRuleConstants.REGION))
+				|| PacmanRuleConstants.REGION_GLOBAL.equalsIgnoreCase(localRuleParam.get(PacmanRuleConstants.REGION))) {
+			localRuleParam.put(PacmanRuleConstants.REGION, defaultRegion);
+		}
+
 
 		MDC.put("executionId", ruleParam.get("executionId")); // this is the logback Mapped Diagnostic Contex
 		MDC.put("ruleId", ruleParam.get(PacmanSdkConstants.POLICY_ID)); // this is the logback Mapped Diagnostic Contex

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/constants/PacmanRuleConstants.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/constants/PacmanRuleConstants.java
@@ -687,4 +687,6 @@ public class PacmanRuleConstants {
     public static final String CLOUD_WATCH_LOGS_ARN= "cloudWatchLogsLogGroupArn";
     public static final String LATEST_CLOUD_WATCH_DELIVERY_TIME="latestCloudWatchLogsDeliveryTime";
     public static final String SERVICE = "Service";
+
+  public static final String REGION_GLOBAL = "global";
 }


### PR DESCRIPTION
## Description

- for all the assetTypes which are not region specific, we added "global" as the default region
- issue: aws sdk client doesn't have an enum "global" expected when creating the client, so it fails
- fix: for assetType account, the default region was given as "us-east-1" which comes from cf_PolicyParams. Since, "global" was used as alternative for UI, we are fixing this by setting the default region if the region of the account is null/global

### Problem
aws sdk client doesn't have an enum "global" expected when creating the client

### Solution
setting the default region from cf_PolicyParams if the region of the account is null/global

## Fixes # (issue if any)
policy "Enable AWS Config service"

## Type of change

**Please delete options that are not relevant.**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] replicated the issue by running the policy in local.
- [x] applied the fix and ran the policy. It was able to create the aws sdk client. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
