### PR TITLE
fix:[CORE-1881] EnableCaching needs proxying through interface

### DIFF
--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/AzureDiscoveryApplication.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/AzureDiscoveryApplication.java
@@ -1,13 +1,18 @@
 package com.tmobile.pacbot.azure.inventory;
 
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.Map;
 
 @Configuration
+@EnableCaching
 @ComponentScan({"com.tmobile.pacbot.azure.inventory", "com.tmobile.pacman.commons.database", "com.tmobile.pacman.commons.secrets"})
 public class AzureDiscoveryApplication {
 
@@ -16,6 +21,11 @@ public class AzureDiscoveryApplication {
         AzureFetchOrchestrator orchestrator = context.getBean(AzureFetchOrchestrator.class);
 
         return orchestrator.orchestrate();
+    }
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager("PolicyDefinitionVH");
     }
 }
 

--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/PolicyDefinitionInventoryCollector.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/PolicyDefinitionInventoryCollector.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -21,7 +20,6 @@ import java.util.Map;
 import static com.tmobile.pacbot.azure.inventory.util.InventoryConstants.REGION_GLOBAL;
 
 @Component
-@EnableCaching
 public class PolicyDefinitionInventoryCollector implements Collector {
 
     private static final Logger log = LoggerFactory.getLogger(PolicyDefinitionInventoryCollector.class);

--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/PolicyStatesInventoryCollector.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/collector/PolicyStatesInventoryCollector.java
@@ -29,7 +29,7 @@ public class PolicyStatesInventoryCollector implements Collector {
     @Autowired
     AzureCredentialProvider azureCredentialProvider;
     @Autowired
-    private PolicyDefinitionInventoryCollector policyDefinitionInventoryCollector;
+    private Collector policyDefinitionInventoryCollector;
 
     @Override
     public List<? extends AzureVH> collect() {
@@ -37,7 +37,7 @@ public class PolicyStatesInventoryCollector implements Collector {
     }
 
     public List<PolicyStatesVH> collect(SubscriptionVH subscription) {
-        List<PolicyDefinitionVH> policyDefinitionList = policyDefinitionInventoryCollector.collect(subscription);
+        List<PolicyDefinitionVH> policyDefinitionList = (List<PolicyDefinitionVH>) policyDefinitionInventoryCollector.collect(subscription);
 
         List<PolicyStatesVH> policyStatesList = new ArrayList<>();
         String accessToken = azureCredentialProvider.getToken(subscription.getTenant());

--- a/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/file/AssetDataFactory.java
+++ b/jobs/azure-discovery/src/main/java/com/tmobile/pacbot/azure/inventory/file/AssetDataFactory.java
@@ -79,7 +79,7 @@ public class AssetDataFactory {
     @Autowired
     PolicyStatesInventoryCollector policyStatesInventoryCollector;
     @Autowired
-    PolicyDefinitionInventoryCollector policyDefinitionInventoryCollector;
+    Collector policyDefinitionInventoryCollector;
     @Autowired
     SitesInventoryCollector sitesInventoryCollector;
     @Autowired


### PR DESCRIPTION
## Description

- using @EnableCaching needs the class to be proxied through interface
- so, autowired the class that uses caching through interface so its correctly proxied
- added missing config for cache manager

### Problem
spring is not able to proxy the class autowired through impl

### Solution
autowired by interface

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Replicated the issue by running in local by adding azure-collector as a dependent module for policy-engine
- [ ] after fix, run the batch application and verify the data files created successfully

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
