### PR TITLE
fix:[CORE-1893] Add NPE check for optional fields in Request/Deny exemption

### DIFF
--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/domain/AuditTrailDTO.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/domain/AuditTrailDTO.java
@@ -6,7 +6,7 @@ import lombok.Value;
 import java.util.Map;
 
 @Value
-@Builder(setterPrefix = "with", toBuilder = true)
+@Builder(setterPrefix = "with", toBuilder = true, builderClassName = "Builder")
 public class AuditTrailDTO {
 
     String id;

--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/repository/ComplianceRepositoryImpl.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/repository/ComplianceRepositoryImpl.java
@@ -103,6 +103,8 @@ import com.tmobile.pacman.api.compliance.domain.ResponseWithOrder;
 import com.tmobile.pacman.api.compliance.domain.PolicyDetails;
 import com.tmobile.pacman.api.compliance.service.NotificationService;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 /**
  * The Class ComplianceRepositoryImpl.
  */
@@ -2342,9 +2344,13 @@ public class ComplianceRepositoryImpl implements ComplianceRepository, Constants
                         String _index = dataSource;
                         String _type = targetType + "_audit";
                         if(!skipAuditTrail) {
-                            Map<String, String> optionalAuditFields = new HashMap<>(2);
-                            optionalAuditFields.put(Constants.ISSUE_EXEMPTION_EXPIRY_DATE, sdf.format(issuesException.getExceptionEndDate()));
-                            optionalAuditFields.put(Constants.ISSUE_EXEMPTION_REASON, issuesException.getExceptionReason());
+                            Map<String, String> optionalAuditFields = Collections.emptyMap();
+                            if (issuesException.getExceptionEndDate() != null) {
+                                optionalAuditFields.put(Constants.ISSUE_EXEMPTION_EXPIRY_DATE, sdf.format(issuesException.getExceptionEndDate()));
+                            }
+                            if (isNotBlank(issuesException.getExceptionReason())) {
+                                optionalAuditFields.put(Constants.ISSUE_EXEMPTION_REASON, issuesException.getExceptionReason());
+                            }
                             AuditTrailDTO auditTrailDTO = AuditTrailDTO.builder()
                                     .withId(id)
                                     .withAssetGroup(assetGroup)
@@ -2354,7 +2360,7 @@ public class ComplianceRepositoryImpl implements ComplianceRepository, Constants
                                     .withDocType(_type)
                                     .withTarget(target)
                                     .withParentDetailsMap(parentDetMap)
-                                    .withOptionalAuditFields(optionalAuditFields)
+                                    .withOptionalAuditFields(optionalAuditFields.isEmpty() ? null : optionalAuditFields)
                                     .build();
 
                             builderRequestAudit.append(String.format(actionTemplateAudit, _index, id)).append(createAuditTrail(auditTrailDTO) + "\n");


### PR DESCRIPTION
## Description

- handled NPE for optional fields during Request/Deny exemption
- For Revoke request and Deny exemption, the reason and expiry date are null

### Problem
NPE when optional fields are null

### Solution
handled NPE checks

## Fixes # (issue if any)
NPE

## Type of change

**Please delete options that are not relevant.**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Login as a read-only user and request exemption for a violation
- [x] Revoke the request using the same read-only user. This should revoke the request successfully
- [x] request exemption for a violation as a read-only again.
- [x] Login as admin user and deny the exemption request. This should deny the request successfully

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
