### PR TITLE
feat:[CORE-1886] Save security group on asset group creation/updation

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -3278,3 +3278,10 @@ UPDATE cf_Target SET displayName='IAM User' WHERE targetName in ('iamuser','iamu
 UPDATE cf_Target SET displayName='KMS Key' WHERE targetName in ('kms','kmskey');
 UPDATE cf_Target SET displayName='Subnet' WHERE targetName in ('subnet','subnets');
 UPDATE cf_Target SET displayName='VM' WHERE targetName in ('virtualmachine','vminstance');
+
+CREATE TABLE IF NOT EXISTS `cf_AssetGroupSecurity` (
+  `groupId` varchar(75) COLLATE utf8_bin NOT NULL,
+  `securityGroup` varchar(75) COLLATE utf8_bin NOT NULL,
+  PRIMARY KEY (`groupId`,`securityGroup`),
+  CONSTRAINT `AssetGroupSecurity_AssetGroupDetails_FK` FOREIGN KEY (`groupId`) REFERENCES `cf_AssetGroupDetails` (`groupId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;


### PR DESCRIPTION
## Description

- created new table to store asset group id and security group relation
- Todo: cherrypick the EE code changes to CE

### Problem
Restrict ag to AD security group

### Solution
save the relation between ag and security group id 

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] execute the db script and verify table is created 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
