### PR TITLE
fix:[CUS-278] Corrected the filenames for account and dms target types

### DIFF
--- a/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/file/FileManager.java
+++ b/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/file/FileManager.java
@@ -1266,7 +1266,7 @@ public class FileManager {
 
         fieldNames = "replicationInstanceArn`replicationInstanceIdentifier`availabilityZone`multiAZ`kmsKeyId`publiclyAccessible";
         keys = "discoverydate`accountid`accountname`region`replicationinstancearn`replicationinstanceid`availabilityzone`multiaz`kmskeyid`publiclyAccessible";
-        FileGenerator.generateJson(fileInfoMap, fieldNames, "aws-fileInfoMap.data", keys);
+        FileGenerator.generateJson(fileInfoMap, fieldNames, "aws-dms.data", keys);
 
     }
 
@@ -1824,7 +1824,7 @@ public class FileManager {
         String keys;
         fieldNames = "cloudtrailName`securityTopicARN`securityTopicEndpoint";
         keys = "discoverydate`accountid`accountname`region`cloudtrailname`securitytopicarn`securitytopicendpoint";
-        FileGenerator.generateJson(fileInfoMap, fieldNames, "aws-fileInfoMap.data", keys);
+        FileGenerator.generateJson(fileInfoMap, fieldNames, "aws-account.data", keys);
     }
 
     /**
@@ -1864,7 +1864,7 @@ public class FileManager {
     /**
      * Generate CloudWatch fileInfoMap files.
      *
-     * @param cloudwatch log and filter map
+     * @param fileInfoMap cloudwatch log and filter map
      */
     public static void generateCloudWatchLogsFiles(Map<String, List<CloudWatchLogsVH>> fileInfoMap) {
         String fieldNames;


### PR DESCRIPTION
## Description

### Problem
Because of the wrong filenames, AWS collector stopped collecting assets for Account and DMS.

### Solution
Corrected the file names accordingly.

## Type of change

**Please delete options that are not relevant.**

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran the collector and can see the data appearing in S3 files.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code

## **Other Information**:

## List any documentation updates that are needed for the Wiki
