### PR TITLE
fix:[CORE-1914] Corrected the time format for default asset group

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -1108,7 +1108,7 @@ INSERT IGNORE INTO `cf_Datasource` (dataSourceId,dataSourceName,dataSourceDesc,c
 
 /*Insert Data Asset Group to necessary tables*/
 
-INSERT IGNORE INTO cf_AssetGroupDetails (groupId,groupName,dataSource,displayName,groupType,createdBy,createdUser,createdDate,modifiedUser,modifiedDate,description,aliasQuery,isVisible) VALUES ('201','aws','aws','AWS','admin','Cloud Security','','','pacman','03/26/2018 23:00','Asset Group to segregate all data related to aws.','',true);
+INSERT IGNORE INTO cf_AssetGroupDetails (groupId,groupName,dataSource,displayName,groupType,createdBy,createdUser,createdDate,modifiedUser,modifiedDate,description,aliasQuery,isVisible) VALUES ('201','aws','aws','AWS','admin','Cloud Security','',now(),'pacman',now(),'Asset Group to segregate all data related to aws.','',true);
 
 /*Insert Target data in required table*/
 INSERT IGNORE INTO `cf_Target` (`targetName`,`displayName`,`targetDesc`,`category`,`dataSourceName`,`targetConfig`,`status`,`userId`,`endpoint`,`createdDate`,`modifiedDate`,`domain`) VALUES ('subscription','Subscription','Azure subscription','','azure','{"key":"id","id":"id",\"name\":\"name\"}','enabled','admin',concat(@eshost,':',@esport,'/azure_subscription'),'2022-06-23','2022-06-23','Infra & Platforms');


### PR DESCRIPTION
## Description

### Problem
Asset Group screen showing the error for fresh installs. Due to an incorrect date values for AWS record post converting the column to timestamp.

### Solution
Removed the default data value and inserted the current timestamp for the default AWS asset group.

## Type of change

**Please delete options that are not relevant.**

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Inserted a few sample asset group records into saasdev using `now()` function and was able to see records inserted using the proper timestamp value and the asset group screen is not broken in saasdev.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas

## **Other Information**:

## List any documentation updates that are needed for the Wiki
