### PR TITLE
fix:[UIUX-572]fixed bug related to duplicate filter options

### DIFF
--- a/webapp/src/app/shared/services/filter-management.service.ts
+++ b/webapp/src/app/shared/services/filter-management.service.ts
@@ -210,9 +210,9 @@
    changeFilterTags(filters, filterTagOptions, currentFilterType, event){    
      try {
          if (currentFilterType) {
-           const filterTags = event.filterValue.map(value => {
-             const v = find(filterTagOptions[event.filterKeyDisplayValue], { name: value });
-             return v?v["id"]:value;
+           const filterTags = event.filterValue.flatMap(value => {
+             const v = filterTagOptions[event.filterKeyDisplayValue].filter(availableOption => availableOption.name === value);
+             return v ? v.map(item => item.id) : [value];
            });
            this.utils.addOrReplaceElement(
              filters,
@@ -313,7 +313,7 @@
        if (!labelsToExcludeSort?.toString().toLowerCase().includes(currentFilterType.optionName.toLowerCase())) {
          filterTagLabels = filterTagLabels.sort((a, b) => a.localeCompare(b));
        }
-       return [filterTagOptions, filterTagLabels];
+     return [filterTagOptions, Array.from(new Set(filterTagLabels))];
    }
  
    createFilterObj(keyDisplayValue, filterKey, validFilterValues){


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issues. Please also include relevant motivation and context. List
any dependencies that are required for this change.
Earlier, We were showing duplicate options if exists and when a filter option was selected we were finding only the first occurrence of corresponding id (expecting one to one correspondence) but now, since we can have multiple id's pointing to same display name.. we are finding all the corresponding id's and also we showing only unique filter optons.

https://paladincloud.atlassian.net/browse/UIUX-572

https://github.com/PaladinCloud/EE/pull/1605
### Problem

### Solution


## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration
1. Confirmed that there no duplicate options available.
2. Confirmed applied filters results correctly.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
