### PR TITLE
fix:[UIUX-580] fixed associated policies not refreshing in asset details

### DIFF
--- a/webapp/src/app/pacman-features/secondary-components/pacman-policy-violations/pacman-policy-violations.component.ts
+++ b/webapp/src/app/pacman-features/secondary-components/pacman-policy-violations/pacman-policy-violations.component.ts
@@ -19,6 +19,8 @@
   Input,
   Output,
   EventEmitter,
+  OnChanges,
+  SimpleChanges,
 } from "@angular/core";
 import { Subscription } from "rxjs";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -38,7 +40,7 @@ import { AssociatedPolicyStatusOrderMap, SeverityOrderMap } from "src/app/shared
   styleUrls: ["./pacman-policy-violations.component.css"],
   providers: [CommonResponseService, AutorefreshService],
 })
-export class PacmanPolicyViolationsComponent implements OnInit, OnDestroy {
+export class PacmanPolicyViolationsComponent implements OnInit, OnChanges, OnDestroy {
   public somedata: any;
   public outerArr: any;
   public allColumns: any;
@@ -156,8 +158,13 @@ export class PacmanPolicyViolationsComponent implements OnInit, OnDestroy {
       .getAssetGroup()
       .subscribe((assetGroupName) => {
         this.selectedAssetGroup = assetGroupName;
-        this.updateComponent();
       });
+  }
+
+  ngOnChanges (changes: SimpleChanges): void {
+    if (changes.resourceId || changes.resourceType) {
+      this.updateComponent();
+    }
   }
 
   ngOnInit() {

--- a/webapp/src/app/pacman-features/secondary-components/pacman-policy-violations/pacman-policy-violations.component.ts
+++ b/webapp/src/app/pacman-features/secondary-components/pacman-policy-violations/pacman-policy-violations.component.ts
@@ -47,7 +47,7 @@ export class PacmanPolicyViolationsComponent implements OnInit, OnChanges, OnDes
   selectedAssetGroup: string;
   public apiData: any;
   public applicationValue: any;
-  public errorMessage: any;
+  public errorMessage: any = '';
   public dataComing = true;
   public showLoader = true;
   public tableHeaderData: any;
@@ -201,7 +201,8 @@ export class PacmanPolicyViolationsComponent implements OnInit, OnChanges, OnDes
       this.currentBucket = [];
       // this.bucketNumber = 0;
       this.dataTableData = [];
-      this.tableDataLoaded = false;
+      this.policyTableDataLoaded = false;
+      this.associatedPolicies = [];
       this.firstPaginator = 1;
       // this.currentPointer = 0;
       this.showLoader = true;

--- a/webapp/src/app/shared/services/filter-management.service.ts
+++ b/webapp/src/app/shared/services/filter-management.service.ts
@@ -240,7 +240,7 @@
        }
    }
  
-   async changeFilterType ({ currentFilterType, searchText, filterText, currentQueryParams, filtersToBePassed, type, agAndDomain, updateFilterTags, labelsToExcludeSort, ignoreAttributeName = false }) {
+   async changeFilterType ({ currentFilterType, searchText, filterText, currentQueryParams, filtersToBePassed, type, agAndDomain, updateFilterTags, labelsToExcludeSort, ignoreAttributeName = false, extraPayloadProps = {}}){
     if(!currentFilterType){
       return [{}, []];
     }; 
@@ -279,7 +279,8 @@
        let payload: IFilterPayload = {
          attributeName: ignoreAttributeName ? undefined : currentFilterType["optionValue"]?.replace(".keyword", ""),
          //filter: sortedFiltersToBePassed && index>=0?sortedFiltersToBePassed:filtersToBePassed,
-         filter: filtersToBePassed
+         filter: filtersToBePassed,
+         ...extraPayloadProps
        };
  
        if(ag && domain){

--- a/webapp/src/app/shared/table/table.component.css
+++ b/webapp/src/app/shared/table/table.component.css
@@ -377,4 +377,5 @@
 
   .mat-sort-header-container {
       font-family: 'mark-pro';
+      overflow: hidden;
   }

--- a/webapp/src/app/shared/table/table.component.html
+++ b/webapp/src/app/shared/table/table.component.html
@@ -79,6 +79,7 @@
                         aria-sort="descending" 
                         [class.flex-center]="centeredColumns[column]"
                         [style.flex-basis.%]="(100 * columnWidths[column]/denominator)"
+                        [title]="displayToolTip(column)"
                         *ngFor="let column of whiteListColumns" 
                     >
                         <div

--- a/webapp/src/app/shared/table/table.component.ts
+++ b/webapp/src/app/shared/table/table.component.ts
@@ -149,6 +149,7 @@ export class TableComponent implements OnInit, AfterViewInit, OnChanges, OnDestr
 
     rowHeight = 36;
     offset: number;
+    tooltipMessageMap = {}
     private whitelistColumnsChange = new Subject<any>();
     private readonly initialScrollPosition = 2;
 
@@ -284,6 +285,10 @@ export class TableComponent implements OnInit, AfterViewInit, OnChanges, OnDestr
     ngOnDestroy(): void {
         this.destroy$.next();
         this.destroy$.complete();
+    }
+
+    displayToolTip(column:string){
+        return this.tooltipMessageMap[column] ?? column;
     }
 
     updateDenominator(){


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issues. Please also include relevant motivation and context. List
any dependencies that are required for this change.

1. Fixed associated policies not refreshing in asset details.
2. Added loader in associated policies.
3. Added tooltip for column header in lists.
    
https://github.com/PaladinCloud/EE/pull/1611
https://github.com/PaladinCloud/EE/pull/1646
### Problem

### Solution


## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

1. Verified associated policies refreshes correctly when clicked on related asset types.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
