### PR TITLE
fix:[UIUX-592] doughnut chart ui fix

### DIFF
--- a/webapp/src/app/pacman-features/modules/assets/asset-details/asset-details.component.css
+++ b/webapp/src/app/pacman-features/modules/assets/asset-details/asset-details.component.css
@@ -96,7 +96,7 @@
 }
 
 .violations-summary-content{
-  padding: 12px 0px;
+  padding: 16px;
   position: relative;
   min-height: 200px;
 }

--- a/webapp/src/app/pacman-features/modules/assets/asset-details/asset-details.component.html
+++ b/webapp/src/app/pacman-features/modules/assets/asset-details/asset-details.component.html
@@ -36,7 +36,7 @@
                             <div class="graph-chart-cont relative" id="statsDoughnut">
                               <app-doughnut-chart *ngIf="violationErrorMessage=='' && policyData?.totalCount"
                                 [chartContId]="'statsDoughnut'"
-                                [displayLegendText]="false"
+                                [displayLegendText]="true"
                                 [flexTrue]="true"
                                 [graphData]="policyData"
                                 [graphHeight]="widgetHeight"

--- a/webapp/src/app/pacman-features/modules/compliance/card/card.component.css
+++ b/webapp/src/app/pacman-features/modules/compliance/card/card.component.css
@@ -48,7 +48,7 @@ mat-card-content {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    padding: 20px 24px 0;
+    padding: 0 24px;
     width: 100%;
     height: 100%;
     margin: 0;
@@ -91,7 +91,7 @@ mat-card-actions button {
 .chart {
     height: 100%;
     width: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 
 .chart-wrapper {
@@ -132,4 +132,8 @@ mat-card-actions img {
 
 .date-selection-trigger {
     margin-right: 150px;
+}
+
+.graph-chart-cont{
+    flex: 1;
 }

--- a/webapp/src/app/pacman-features/modules/compliance/card/card.component.html
+++ b/webapp/src/app/pacman-features/modules/compliance/card/card.component.html
@@ -3,7 +3,7 @@
         {{ card.header }}
     </mat-card-header>
     <mat-card-content [ngClass]="{'asset-graph':card.id === 3}">
-        <div class="chart" *ngIf="card.id === 1">
+        <div class="chart flex flex-align-center" *ngIf="card.id === 1">
             <div [class.loader]="data.length === 0 && dataError === ''"></div>
             <app-error-message *ngIf="dataError" [selectedValue]="dataError"></app-error-message>
             <app-progress-bar-chart

--- a/webapp/src/app/pacman-features/modules/compliance/card/card.component.html
+++ b/webapp/src/app/pacman-features/modules/compliance/card/card.component.html
@@ -12,7 +12,7 @@
                 (navigateTo)="navigateToViolationsByCategory($event)"
             ></app-progress-bar-chart>
         </div>
-        <div class="chart" *ngIf="card.id === 2">
+        <div class="chart flex" *ngIf="card.id === 2">
             <div [class.loader]="!data && dataError === ''"></div>
             <app-error-message *ngIf="dataError" [selectedValue]="dataError"></app-error-message>
             <div class="graph-chart-cont relative" id="dashboardDoughnut">

--- a/webapp/src/app/pacman-features/modules/compliance/progress-bar-chart/progress-bar-chart.component.css
+++ b/webapp/src/app/pacman-features/modules/compliance/progress-bar-chart/progress-bar-chart.component.css
@@ -1,3 +1,7 @@
+:host{
+    flex: 1;
+}
+
 .label {
     display: flex;
     flex-direction: row;

--- a/webapp/src/app/shared/components/molecules/multi-tab-switcher/multi-tab-switcher.component.css
+++ b/webapp/src/app/shared/components/molecules/multi-tab-switcher/multi-tab-switcher.component.css
@@ -1,9 +1,10 @@
 .switch-wrapper{
     display: flex;
-    background-color: var(--background-white);
+    background-color: var(--interaction-neutral-subtle-normal);
     padding: 4px;
     border-radius: 4px;
     margin-left: auto;
+    border: 1px solid var(--border-normal);
 }
 
 .switch-wrapper ::ng-deep .mat-button-wrapper{
@@ -15,7 +16,8 @@
 }
 
 .isSelected{
-    background-color: #F1F6FF;
+    background-color: var(--background-white);
+    box-shadow: 0px 1px 2px 0px #1018280F, 0px 1px 3px 0px #1018281A;
 }
 
 .isSelected img{

--- a/webapp/src/app/shared/doughnut-chart/doughnut-chart.component.css
+++ b/webapp/src/app/shared/doughnut-chart/doughnut-chart.component.css
@@ -54,7 +54,7 @@
 }
 
 .donut-container-statsDoughnut .graph-legend-cont{
-    margin-top: 2em;
+    margin: 2em 1em;
 }
 
 .legend-text-count {

--- a/webapp/src/app/shared/doughnut-chart/doughnut-chart.component.css
+++ b/webapp/src/app/shared/doughnut-chart/doughnut-chart.component.css
@@ -44,19 +44,20 @@
     font-size: var(--text-body-2-font-size);
     line-height: 20px;
     color: #2E2C34;
-    flex: none;
-    flex-grow: 1;
+    flex: 1;
 }
 
 .graph-legend-cont {
+    flex: 1;
     margin: 1em;
-    justify-content: center;
     flex-wrap: wrap;
 }
 
+.donut-container-statsDoughnut .graph-legend-cont{
+    margin-top: 2em;
+}
+
 .legend-text-count {
-    width: 38px;
-    height: 20px;
     overflow: hidden;
     text-overflow: ellipsis;
     font-family: var(--text-medium-font-family);
@@ -66,9 +67,8 @@
     line-height: 20px;
     text-align: right;
     color: #2E2C34;
-    flex: none;
+    flex: 1;
     order: 0;
-    flex-grow: 0;
 }
 
 .legend-each {
@@ -80,10 +80,15 @@
     text-overflow: ellipsis;
     display: flex;
     align-items: center;
+    border-bottom: 1px solid var(--border-normal);
 }
 
 .graph-outer-container {
     text-align: center;
+}
+
+.statisticsDoughnutChart .graph-outer-container{
+    margin-bottom: 16px;
 }
 
 .showFlex {

--- a/webapp/src/app/shared/doughnut-chart/doughnut-chart.component.ts
+++ b/webapp/src/app/shared/doughnut-chart/doughnut-chart.component.ts
@@ -173,9 +173,11 @@ export class DoughnutChartComponent implements OnInit, OnChanges {
               .append('g');
           }
 
-          this.pie = d3Shape.pie().sort(null)
-            .startAngle(1.1 * Math.PI)
-            .endAngle(3.1 * Math.PI)
+          this.pie = d3Shape
+            .pie()
+            .sort(null)
+            .startAngle(0)
+            .endAngle(2 * Math.PI)
             .value(function (d) { return +d; });
 
           // -------- defines the inner and outer radious--------//


### PR DESCRIPTION
## Description

https://paladincloud.atlassian.net/browse/UIUX-592

When we can fit in the same number of digits for Critical severity, we should show the full number for High too.

### Problem

![bug](https://github.com/PaladinCloud/CE/assets/152586069/33d7056e-830e-4ebe-8bf7-2e40fe63229d)

### Solution

https://github.com/PaladinCloud/CE/assets/152586069/ebc11eeb-ffc6-44f1-8769-a47df116f933

## Fixes # (issue if any)

- Resolving issue with label display for long numbers on the chart.
- Adjusting the starting angle of the donut chart to commence from 0 degrees for improved visualisation.
- Enhancing alignment for all utilised donut charts.
- Improving UI design for multi-tab switching.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
