### PR TITLE
fix:[CORE-1922] Display only enabled asset groups

### DIFF
--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupServiceImpl.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/service/AssetGroupServiceImpl.java
@@ -131,7 +131,7 @@ public class AssetGroupServiceImpl implements AssetGroupService {
 
 	@Override
 	public Page<AssetGroupView> getAllAssetGroupDetails(PluginRequestBody requestBody, final String searchTerm, int page, int size) {
-		StringBuilder query = new StringBuilder("SELECT * FROM cf_AssetGroupDetails ag WHERE LOWER(ag.groupType) <> 'user' ");
+		StringBuilder query = new StringBuilder("SELECT * FROM cf_AssetGroupDetails ag WHERE LOWER(ag.groupType) <> 'user' and isVisible='1'");
 		StringBuilder whereQuery = new StringBuilder("");
 		if (requestBody != null && !requestBody.getFilter().isEmpty()) {
 			for (var entry : requestBody.getFilter().entrySet()) {


### PR DESCRIPTION
## Description

Ops alert is being generated because while listing asset groups we are fetching data for asset groups which are not enabled

### Problem
Ops alert generated for admin API

### Solution
Display only visible asset groups

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Set isvisible=0 in DB
![image](https://github.com/PaladinCloud/CE/assets/103987424/336f2d4b-87de-4283-995a-b3f6e17b7069)

Run API in post man ,
![image](https://github.com/PaladinCloud/CE/assets/103987424/f101171a-5660-4791-b525-6f5df7a621e5)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
