### PR TITLE
fix:[PLG-440] Fix shipper for CQ GCP and Wiz case

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -1244,9 +1244,10 @@ INSERT IGNORE INTO `cf_Target` (`targetName`,`displayName`,`targetDesc`,`categor
 
 
 INSERT IGNORE INTO cf_Target (`targetName`,`targetDesc`,`displayName`,`category`,`dataSourceName`,`targetConfig`,`status`,`userId`,`endpoint`,`createdDate`,`modifiedDate`,`domain`) VALUES ('cloudfunction','GCP Cloud Functions','GCP cloud functions','Security','gcp','{"key":"id","id":"id"}','enabled','admin',concat(@eshost,':',@esport,'/gcp_cloudfunction'),'2023-01-10','2023-01-10','Infra & Platforms');
-INSERT IGNORE INTO cf_Target (`targetName`,`targetDesc`,`displayName`,`category`,`dataSourceName`,`targetConfig`,`status`,`userId`,`endpoint`,`createdDate`,`modifiedDate`,`domain`) VALUES ('cloudfunctiongen1','GCP Cloud Functions Generation 1','GCP cloud functions Generation 1','Security','gcp','{"key":"id","id":"id"}','enabled','admin',concat(@eshost,':',@esport,'/gcp_cloudfunctiongen1'),'2023-01-10','2023-01-10','Infra & Platforms');
 INSERT IGNORE INTO cf_Target (`targetName`,`targetDesc`,`displayName`,`category`,`dataSourceName`,`targetConfig`,`status`,`userId`,`endpoint`,`createdDate`,`modifiedDate`,`domain`) VALUES ('launchtemplate','EC2 Launch Template','AWS EC2 Launch Template','Compute','aws','{"key":"accountid,region,launchTemplateId","id":"launchTemplateId","name":"launchTemplateName"}','enabled','admin@pacbot.org',concat(@eshost,':',@esport,'/aws_launchtemplate/launchtemplate'),'2022-05-06','2022-05-06','Infra & Platforms');
 INSERT IGNORE INTO `cf_Target` (`targetName`,`displayName`, `targetDesc`, `category`, `dataSourceName`, `targetConfig`, `status`, `userId`, `endpoint`, `createdDate`, `modifiedDate`, `domain`) VALUES('gcpdisks','Managed Disks (Gcp)','GCP Disks','security','gcp','{\"key\":\"id\",\"id\":\"id\"}','enabled','admin@pacbot.org',concat(@eshost,':',@esport,'/gcp_gcpdisks/gcpdisks'),'2022-12-5','2022-12-5','Infra & Platforms');
+
+DELETE FROM `cf_Target` WHERE targetType ='cloudfunctiongen1' AND dataSourceName = 'gcp';
 
 INSERT IGNORE INTO cf_AssetGroupTargetDetails (id_,groupId,targetType,attributeName,attributeValue) VALUES ('11501','201','ec2','all','all');
 INSERT IGNORE INTO cf_AssetGroupTargetDetails (id_,groupId,targetType,attributeName,attributeValue) VALUES ('11502','201','s3','all','all');
@@ -1381,12 +1382,12 @@ INSERT IGNORE INTO `cf_AssetGroupTargetDetails` (`id_`, `groupId`, `targetType`,
 
 
 INSERT IGNORE INTO cf_AssetGroupTargetDetails (`id_`, groupId, targetType, attributeName, `attributeValue`) VALUES('a1480aa8-7239-4604-9ab7-916621792f00','e0008397-f74e-4deb-9066-10bdf11202ae','cloudfunction','all','all');
-INSERT IGNORE INTO cf_AssetGroupTargetDetails (`id_`, groupId, targetType, attributeName, `attributeValue`) VALUES('a1480aa8-7239-4604-9ab7-916621792f01','e0008397-f74e-4deb-9066-10bdf11202ae','cloudfunctiongen1','all','all');
 
 delete from `cf_AssetGroupTargetDetails` where targetType ='ecs';
 delete from `cf_AssetGroupTargetDetails` where targetType = 'policydefinitions';
 delete from `cf_AssetGroupTargetDetails` where targetType = 'policyevaluationresults';
 delete from `cf_AssetGroupTargetDetails` where targetType = 'vaultsrbac';
+DELETE FROM `cf_AssetGroupTargetDetails` WHERE targetType = 'cloudfunctiongen1';
 
 /*Insert Domain in required table*/
 

--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -1244,10 +1244,9 @@ INSERT IGNORE INTO `cf_Target` (`targetName`,`displayName`,`targetDesc`,`categor
 
 
 INSERT IGNORE INTO cf_Target (`targetName`,`targetDesc`,`displayName`,`category`,`dataSourceName`,`targetConfig`,`status`,`userId`,`endpoint`,`createdDate`,`modifiedDate`,`domain`) VALUES ('cloudfunction','GCP Cloud Functions','GCP cloud functions','Security','gcp','{"key":"id","id":"id"}','enabled','admin',concat(@eshost,':',@esport,'/gcp_cloudfunction'),'2023-01-10','2023-01-10','Infra & Platforms');
+INSERT IGNORE INTO cf_Target (`targetName`,`targetDesc`,`displayName`,`category`,`dataSourceName`,`targetConfig`,`status`,`userId`,`endpoint`,`createdDate`,`modifiedDate`,`domain`) VALUES ('cloudfunctiongen1','GCP Cloud Functions Generation 1','GCP cloud functions Generation 1','Security','gcp','{"key":"id","id":"id"}','enabled','admin',concat(@eshost,':',@esport,'/gcp_cloudfunctiongen1'),'2023-01-10','2023-01-10','Infra & Platforms');
 INSERT IGNORE INTO cf_Target (`targetName`,`targetDesc`,`displayName`,`category`,`dataSourceName`,`targetConfig`,`status`,`userId`,`endpoint`,`createdDate`,`modifiedDate`,`domain`) VALUES ('launchtemplate','EC2 Launch Template','AWS EC2 Launch Template','Compute','aws','{"key":"accountid,region,launchTemplateId","id":"launchTemplateId","name":"launchTemplateName"}','enabled','admin@pacbot.org',concat(@eshost,':',@esport,'/aws_launchtemplate/launchtemplate'),'2022-05-06','2022-05-06','Infra & Platforms');
 INSERT IGNORE INTO `cf_Target` (`targetName`,`displayName`, `targetDesc`, `category`, `dataSourceName`, `targetConfig`, `status`, `userId`, `endpoint`, `createdDate`, `modifiedDate`, `domain`) VALUES('gcpdisks','Managed Disks (Gcp)','GCP Disks','security','gcp','{\"key\":\"id\",\"id\":\"id\"}','enabled','admin@pacbot.org',concat(@eshost,':',@esport,'/gcp_gcpdisks/gcpdisks'),'2022-12-5','2022-12-5','Infra & Platforms');
-
-DELETE FROM `cf_Target` WHERE targetName ='cloudfunctiongen1' AND dataSourceName = 'gcp';
 
 INSERT IGNORE INTO cf_AssetGroupTargetDetails (id_,groupId,targetType,attributeName,attributeValue) VALUES ('11501','201','ec2','all','all');
 INSERT IGNORE INTO cf_AssetGroupTargetDetails (id_,groupId,targetType,attributeName,attributeValue) VALUES ('11502','201','s3','all','all');
@@ -1382,12 +1381,12 @@ INSERT IGNORE INTO `cf_AssetGroupTargetDetails` (`id_`, `groupId`, `targetType`,
 
 
 INSERT IGNORE INTO cf_AssetGroupTargetDetails (`id_`, groupId, targetType, attributeName, `attributeValue`) VALUES('a1480aa8-7239-4604-9ab7-916621792f00','e0008397-f74e-4deb-9066-10bdf11202ae','cloudfunction','all','all');
+INSERT IGNORE INTO cf_AssetGroupTargetDetails (`id_`, groupId, targetType, attributeName, `attributeValue`) VALUES('a1480aa8-7239-4604-9ab7-916621792f01','e0008397-f74e-4deb-9066-10bdf11202ae','cloudfunctiongen1','all','all');
 
 delete from `cf_AssetGroupTargetDetails` where targetType ='ecs';
 delete from `cf_AssetGroupTargetDetails` where targetType = 'policydefinitions';
 delete from `cf_AssetGroupTargetDetails` where targetType = 'policyevaluationresults';
 delete from `cf_AssetGroupTargetDetails` where targetType = 'vaultsrbac';
-DELETE FROM `cf_AssetGroupTargetDetails` WHERE targetType = 'cloudfunctiongen1';
 
 /*Insert Domain in required table*/
 

--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -1247,7 +1247,7 @@ INSERT IGNORE INTO cf_Target (`targetName`,`targetDesc`,`displayName`,`category`
 INSERT IGNORE INTO cf_Target (`targetName`,`targetDesc`,`displayName`,`category`,`dataSourceName`,`targetConfig`,`status`,`userId`,`endpoint`,`createdDate`,`modifiedDate`,`domain`) VALUES ('launchtemplate','EC2 Launch Template','AWS EC2 Launch Template','Compute','aws','{"key":"accountid,region,launchTemplateId","id":"launchTemplateId","name":"launchTemplateName"}','enabled','admin@pacbot.org',concat(@eshost,':',@esport,'/aws_launchtemplate/launchtemplate'),'2022-05-06','2022-05-06','Infra & Platforms');
 INSERT IGNORE INTO `cf_Target` (`targetName`,`displayName`, `targetDesc`, `category`, `dataSourceName`, `targetConfig`, `status`, `userId`, `endpoint`, `createdDate`, `modifiedDate`, `domain`) VALUES('gcpdisks','Managed Disks (Gcp)','GCP Disks','security','gcp','{\"key\":\"id\",\"id\":\"id\"}','enabled','admin@pacbot.org',concat(@eshost,':',@esport,'/gcp_gcpdisks/gcpdisks'),'2022-12-5','2022-12-5','Infra & Platforms');
 
-DELETE FROM `cf_Target` WHERE targetType ='cloudfunctiongen1' AND dataSourceName = 'gcp';
+DELETE FROM `cf_Target` WHERE targetName ='cloudfunctiongen1' AND dataSourceName = 'gcp';
 
 INSERT IGNORE INTO cf_AssetGroupTargetDetails (id_,groupId,targetType,attributeName,attributeValue) VALUES ('11501','201','ec2','all','all');
 INSERT IGNORE INTO cf_AssetGroupTargetDetails (id_,groupId,targetType,attributeName,attributeValue) VALUES ('11502','201','s3','all','all');

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/EntityManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/EntityManager.java
@@ -115,7 +115,7 @@ public class EntityManager implements Constants {
         Map<String, String> types = ConfigManager.getTypesWithDisplayName(datasource);
         Iterator<Map.Entry<String, String>> itr = types.entrySet().iterator();
         String type = "";
-        LOGGER.info("*** Start Colleting Entity Info ***");
+        LOGGER.info("Start Collecting Entity Info");
         List<String> filters = new ArrayList<>(Collections.singletonList("_docid"));
 
         // Preserve attributes from current asset data if exists
@@ -125,7 +125,7 @@ public class EntityManager implements Constants {
         }
 
         EntityAssociationManager childTypeManager = new EntityAssociationManager();
-        ViolationAssociationManager violationAssociatManager = new ViolationAssociationManager();
+        ViolationAssociationManager violationAssociationManager = new ViolationAssociationManager();
         while (itr.hasNext()) {
             try {
                 Map.Entry<String, String> entry = itr.next();
@@ -165,7 +165,7 @@ public class EntityManager implements Constants {
                     stats.putAll(uploadInfo);
                     stats.put("errorUpdates", errUpdateInfo);
                     errorList.addAll(childTypeManager.uploadAssociationInfo(datasource, type));
-                    errorList.addAll(violationAssociatManager.uploadViolationInfo(datasource, type));
+                    errorList.addAll(violationAssociationManager.uploadViolationInfo(datasource, type));
 
                 } else {
                     Map<String, Long> errUpdateInfo = ErrorManager.getInstance(datasource).handleError(indexName, type, loaddate, errorList, true);
@@ -189,7 +189,7 @@ public class EntityManager implements Constants {
             }
 
         }
-        LOGGER.info("*** End Colleting Entity Info ***");
+        LOGGER.info("End Collecting Entity Info");
         return errorList;
     }
 
@@ -209,7 +209,7 @@ public class EntityManager implements Constants {
         try {
             entities = Util.fetchDataFromS3(s3Account, s3Region, s3Role, bucketName, path);
         } catch (Exception e) {
-            LOGGER.error("Exception in collecting data for {}", type, e);
+            LOGGER.error("Exception in collecting data for {} from {}", type, path, e);
             Map<String, String> errorMap = new HashMap<>();
             errorMap.put(ERROR, "Exception in collecting data for " + type + " from " + path);
             errorMap.put(ERROR_TYPE, WARN);

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/EntityManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/EntityManager.java
@@ -265,8 +265,7 @@ public class EntityManager implements Constants {
             } else if (entityInfo.containsKey("projectId")) {
                 entityInfo.put("accountid", entityInfo.get("projectId"));
             }
-            // For GCP CQ Collector accountName will be fetched from RDS using accountId
-            // Only if not being set earlier
+            // For CQ Collector accountName will be fetched from RDS using accountId only if not being set earlier
             if ("gcp".equalsIgnoreCase(dataSource) && !entityInfo.containsKey("accountname")) {
                 String projectId = String.valueOf(entityInfo.get("projectId"));
                 if (null != projectId && !projectId.isEmpty()) {

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ExternalPolicies.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ExternalPolicies.java
@@ -60,7 +60,7 @@ public class ExternalPolicies {
      * @param dataSource the data source
      */
     public void uploadPolicyDefinition(String dataSource) {
-        LOGGER.info("Started upload external policies definition for {}", dataSource);
+        LOGGER.info("Started upload policies definition for {}", dataSource);
         AmazonS3 s3Client = AmazonS3ClientBuilder.standard().withCredentials(
                 new AWSStaticCredentialsProvider(new CredentialProvider().getCredentials(s3Account, s3Role))).withRegion(s3Region).build();
         ObjectMapper objectMapper = new ObjectMapper();

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ExternalPolicies.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ExternalPolicies.java
@@ -60,13 +60,18 @@ public class ExternalPolicies {
      * @param dataSource the data source
      */
     public void uploadPolicyDefinition(String dataSource) {
-        LOGGER.info("Started upload policy definition for {}", dataSource);
+        LOGGER.info("Started upload external policies definition for {}", dataSource);
         AmazonS3 s3Client = AmazonS3ClientBuilder.standard().withCredentials(
                 new AWSStaticCredentialsProvider(new CredentialProvider().getCredentials(s3Account, s3Role))).withRegion(s3Region).build();
         ObjectMapper objectMapper = new ObjectMapper();
 
         try {
             String filePrefix = dataSource + "-policy";
+
+            if (!s3Client.doesObjectExist(bucketName, dataPath + "/" + filePrefix + ".data")) {
+                LOGGER.info("No external policies to upload");
+                return;
+            }
 
             List<Map<String, Object>> entities = new ArrayList<>();
             S3Object entitiesData = s3Client.getObject(new GetObjectRequest(bucketName, dataPath + "/" + filePrefix + ".data"));

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ExternalPolicies.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ExternalPolicies.java
@@ -60,7 +60,7 @@ public class ExternalPolicies {
      * @param dataSource the data source
      */
     public void uploadPolicyDefinition(String dataSource) {
-        LOGGER.info("Started upload policies definition for {}", dataSource);
+        LOGGER.info("Started upload policy definition for {}", dataSource);
         AmazonS3 s3Client = AmazonS3ClientBuilder.standard().withCredentials(
                 new AWSStaticCredentialsProvider(new CredentialProvider().getCredentials(s3Account, s3Role))).withRegion(s3Region).build();
         ObjectMapper objectMapper = new ObjectMapper();
@@ -69,7 +69,7 @@ public class ExternalPolicies {
             String filePrefix = dataSource + "-policy";
 
             if (!s3Client.doesObjectExist(bucketName, dataPath + "/" + filePrefix + ".data")) {
-                LOGGER.info("No external policies to upload");
+                LOGGER.info("No policy to upload");
                 return;
             }
 

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ViolationAssociationManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ViolationAssociationManager.java
@@ -99,7 +99,7 @@ public class ViolationAssociationManager {
 				obj.put(type + "_relations", relMap);
 			});
 			LOGGER.info("Collected : {}", entities.size());
-			ESManager.uploadData(indexName, entities, dataSource);
+			ESManager.uploadData(indexName, entities);
 			ESManager.deleteOldDocuments(indexName, docType, "_loaddate.keyword", loaddate);
 			String auditDocType = "issue_" + type + "_audit";
 			List<Map<String, Object>> auditLogEntites = createAuditLog(dataSource, type, entities);

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/error/ErrorManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/error/ErrorManager.java
@@ -93,7 +93,7 @@ public abstract class ErrorManager implements Constants {
                     inventoryErrors = objectMapper.readValue(reader.lines().collect(Collectors.joining("\n")), new TypeReference<List<Map<String, String>>>() {
                     });
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 LOGGER.error("Exception in collecting inventory error data", e);
                 Map<String, String> errorMap = new HashMap<>();
                 errorMap.put(ERROR, "Exception in collecting inventory error data");
@@ -109,7 +109,7 @@ public abstract class ErrorManager implements Constants {
     /**
      * Gets the error info.
      *
-     * @param errorList  the error list
+     * @param errorList the error list
      * @return the error info
      */
     public Map<String, List<Map<String, String>>> getErrorInfo(List<Map<String, String>> errorList) {

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/es/ESManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/es/ESManager.java
@@ -98,12 +98,12 @@ public class ESManager implements Constants {
         List<String> errors = new ArrayList<>();
         String actionTemplate = "{ \"index\" : { \"_index\" : \"%s\", \"_id\" : \"%s\" } }%n";
 
-        LOGGER.info("*********UPLOADING*** {}:::{}", type, index);
+        LOGGER.info("Uploading {}:::{}", type, index);
 
         String keys = ConfigManager.getKeyForType(index, type);
         String[] _keys = keys.split(",");
         if (null != docs && !docs.isEmpty()) {
-            LOGGER.info("*********# of docs *** {}", docs.size());
+            LOGGER.info("# of docs {}", docs.size());
             StringBuilder bulkRequest = new StringBuilder();
             int i = 0;
             for (Map<String, Object> doc : docs) {
@@ -188,7 +188,7 @@ public class ESManager implements Constants {
                 LOGGER.error(responseStr);
             }
         } catch (ParseException | IOException e) {
-            LOGGER.error("Error in uploading data", e);
+            LOGGER.error("Error uploading data", e);
         }
     }
 
@@ -201,7 +201,7 @@ public class ESManager implements Constants {
         try {
             Response refrehsResponse = invokeAPI("POST", index + "/" + "_refresh", null);
             if (refrehsResponse != null && HttpStatus.SC_OK != refrehsResponse.getStatusLine().getStatusCode()) {
-                LOGGER.error("Refreshing index %s failed", index, refrehsResponse);
+                LOGGER.error("Refreshing index {} failed", index);
             }
         } catch (IOException e) {
             LOGGER.error("Error in refresh ", e);
@@ -210,7 +210,7 @@ public class ESManager implements Constants {
     }
 
     /**
-     * Method not used by the entity upload.But to append data to speific index
+     * Method not used by the entity upload. But to append data to specific index
      *
      * @param index   the index
      * @param type    the type
@@ -225,8 +225,9 @@ public class ESManager implements Constants {
         if (refresh) {
             endpoint = endpoint + "?refresh=true";
         }
-        LOGGER.info("*********UPLOADING*** {}", type);
+
         if (null != docs && !docs.isEmpty()) {
+            LOGGER.info("Uploading {}:::{}", type, index);
             StringBuilder bulkRequest = new StringBuilder();
             int i = 0;
             for (Map<String, Object> doc : docs) {
@@ -705,7 +706,7 @@ public class ESManager implements Constants {
      */
     public static void uploadData(String index, String parentType, String type, List<Map<String, Object>> docs, String[] key, String dataSource) {
         String actionTemplate = "{ \"index\" : { \"_index\" : \"%s\" , \"routing\" : \"%s\" } }";
-        LOGGER.info("*********UPLOADING*** {}:::{}", type, index);
+        LOGGER.info("Uploading {}:::{}", type, index);
         if (null != docs && !docs.isEmpty()) {
             StringBuilder bulkRequest = new StringBuilder();
             int i = 0;
@@ -733,9 +734,9 @@ public class ESManager implements Constants {
         }
     }
 
-    public static void uploadData(String index, List<Map<String, Object>> docs, String dataSource) {
+    public static void uploadData(String index, List<Map<String, Object>> docs) {
         String actionTemplate = "{ \"index\" : { \"_index\" : \"%s\" , \"_id\" : \"%s\", \"routing\" : \"%s\" } }";
-        LOGGER.info("*********UPLOADING*** {}:::{}", index);
+        LOGGER.info("Uploading into index {}", index);
         if (null != docs && !docs.isEmpty()) {
             StringBuilder bulkRequest = new StringBuilder();
             int i = 0;
@@ -763,7 +764,7 @@ public class ESManager implements Constants {
         String actionTemplate = "{ \"index\" : { \"_index\" : \"%s\" , \"_id\" : \"%s\", \"routing\" : \"%s\" } }";
         long dateInMillSec = new Date().getTime();
 
-        LOGGER.info("*********UPLOADING*** {}:::{}", index);
+        LOGGER.info("Uploading audit log {}", index);
         if (null != docs && !docs.isEmpty()) {
             StringBuilder bulkRequest = new StringBuilder();
             int i = 0;


### PR DESCRIPTION
## Description

Condition for CQ GCP case breaks data shipping for Wiz GCP data by setting `aacountname` to `null` because with Wiz we don't have all customer accounts and those data fields (such as `accountid` and `accountname`) are set in mapper.
### Problem

### Solution
Added condition to the shipper so when account name is set - it's not get set again from the DB (crucial for Wiz).
Meanwhile updating all GCP mapping files in this [PLG PR 155](https://github.com/PaladinCloud/Plugins/pull/155) so they won't have '-' as a project name.

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Did run shipper with changes - all project IDs where loaded properly for GCP (via regular CQ collection).
![image](https://github.com/PaladinCloud/CE/assets/133698330/15f99a47-8ffc-4088-92f2-69fb29f26578)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas

## **Other Information**:

## List any documentation updates that are needed for the Wiki
