### PR TITLE
fix:[PLG-411]Bugfixes-CheckMarxAssetType Display fix

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -3278,3 +3278,4 @@ UPDATE cf_Target SET displayName='IAM User' WHERE targetName in ('iamuser','iamu
 UPDATE cf_Target SET displayName='KMS Key' WHERE targetName in ('kms','kmskey');
 UPDATE cf_Target SET displayName='Subnet' WHERE targetName in ('subnet','subnets');
 UPDATE cf_Target SET displayName='VM' WHERE targetName in ('virtualmachine','vminstance');
+UPDATE cf_Target SET displayName = 'Environment', endpoint = concat(@eshost,':',@esport,'/checkmarx_environment') WHERE dataSourceName in ('checkmarx');

--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -3278,4 +3278,4 @@ UPDATE cf_Target SET displayName='IAM User' WHERE targetName in ('iamuser','iamu
 UPDATE cf_Target SET displayName='KMS Key' WHERE targetName in ('kms','kmskey');
 UPDATE cf_Target SET displayName='Subnet' WHERE targetName in ('subnet','subnets');
 UPDATE cf_Target SET displayName='VM' WHERE targetName in ('virtualmachine','vminstance');
-UPDATE cf_Target SET displayName = 'Environment', endpoint = concat(@eshost,':',@esport,'/checkmarx_environment') WHERE dataSourceName in ('checkmarx');
+UPDATE cf_Target SET displayName = 'Environment', endpoint = concat(@eshost,':',@esport,'/checkmarx_environment') WHERE dataSourceName in ('checkmarx') AND targetName = 'environment';


### PR DESCRIPTION
## Description
During Testing at SAASDEV it has been identified, asset type incorrectly displays as "Dast Assets" instead of environment  and also ES url is wrong at DB. So corrected both the bugs identified as part of this PR
### Problem
Incorrect AssetType for Checkmarx

### Solution
Make changes to AssetType

## Fixes # (issue if any)
DB Change
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
-
## How Has This Been Tested?
Tested at SAASDEV after making changing db changes. Before fix below graph had Dast Assets, after fix it changed to Environment
**Dast Assets================>Environment**

![image](https://github.com/PaladinCloud/CE/assets/138756904/49cd3b39-0c38-4edd-bcea-fc85932d182b)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
