### PR TITLE
fix: Removing the provided scope for commons so that they are included in the final jar

### DIFF
--- a/jobs/azure-discovery/pom.xml
+++ b/jobs/azure-discovery/pom.xml
@@ -22,7 +22,6 @@
       <groupId>com.paladincloud</groupId>
       <artifactId>batch-commons</artifactId>
       <version>1.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>com.amazonaws</groupId>

--- a/jobs/gcp-discovery/pom.xml
+++ b/jobs/gcp-discovery/pom.xml
@@ -98,7 +98,6 @@
       <groupId>com.paladincloud</groupId>
       <artifactId>batch-commons</artifactId>
       <version>1.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/jobs/pacman-aqua-enricher/pom.xml
+++ b/jobs/pacman-aqua-enricher/pom.xml
@@ -57,7 +57,6 @@
       <groupId>com.paladincloud</groupId>
       <artifactId>batch-commons</artifactId>
       <version>1.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/jobs/pacman-awsrules/pom.xml
+++ b/jobs/pacman-awsrules/pom.xml
@@ -105,7 +105,6 @@
       <groupId>com.paladincloud</groupId>
       <artifactId>batch-commons</artifactId>
       <version>1.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/jobs/pacman-cloud-discovery/pom.xml
+++ b/jobs/pacman-cloud-discovery/pom.xml
@@ -53,7 +53,6 @@
       <groupId>com.paladincloud</groupId>
       <artifactId>batch-commons</artifactId>
       <version>1.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/jobs/pacman-cloud-notifications/pom.xml
+++ b/jobs/pacman-cloud-notifications/pom.xml
@@ -102,7 +102,6 @@
 			<groupId>com.paladincloud</groupId>
 			<artifactId>batch-commons</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
-			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>com.amazonaws</groupId>

--- a/jobs/pacman-data-shipper/pom.xml
+++ b/jobs/pacman-data-shipper/pom.xml
@@ -58,7 +58,6 @@
       <groupId>com.paladincloud</groupId>
       <artifactId>batch-commons</artifactId>
       <version>1.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/jobs/pacman-qualys-enricher/pom.xml
+++ b/jobs/pacman-qualys-enricher/pom.xml
@@ -49,7 +49,6 @@
       <groupId>com.paladincloud</groupId>
       <artifactId>batch-commons</artifactId>
       <version>1.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/jobs/pacman-rule-engine-2.0/pom.xml
+++ b/jobs/pacman-rule-engine-2.0/pom.xml
@@ -144,7 +144,6 @@
       <groupId>com.paladincloud</groupId>
       <artifactId>batch-commons</artifactId>
       <version>1.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/jobs/pacman-tenable-enricher/pom.xml
+++ b/jobs/pacman-tenable-enricher/pom.xml
@@ -62,7 +62,6 @@
       <groupId>com.paladincloud</groupId>
       <artifactId>batch-commons</artifactId>
       <version>1.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>

--- a/jobs/recommendation-enricher/pom.xml
+++ b/jobs/recommendation-enricher/pom.xml
@@ -23,7 +23,6 @@
       <groupId>com.paladincloud</groupId>
       <artifactId>batch-commons</artifactId>
       <version>1.0.0-SNAPSHOT</version>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>*</groupId>


### PR DESCRIPTION
## Description

Removing the provided scope as the batch-commons are not available at the container. We need to include these classes in the JAR.

## Type of change

## How Has This Been Tested?

Build AWS collector locally and could see batch commons being included in the final JAR.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project


## **Other Information**:

## List any documentation updates that are needed for the Wiki
