### PR TITLE
fix:[CORE-1962] Increase created and modified user column length for AssetGroupDetails

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -3310,3 +3310,35 @@ DELIMITER ;
 
 CALL AddColumnIfNotExists('cf_Accounts', 'updatedTime', 'TIMESTAMP');
 CALL AddColumnIfNotExists('cf_Accounts', 'updatedBy', 'VARCHAR(150)');
+
+DELIMITER $$
+DROP PROCEDURE IF EXISTS alter_cf_AssetGroupDetails_alter_user_length $$
+CREATE PROCEDURE alter_cf_AssetGroupDetails_alter_user_length()
+BEGIN
+    DECLARE createdUsercolumnLength INT;
+    DECLARE modifiedUsercolumnLength INT;
+
+    SELECT CHARACTER_MAXIMUM_LENGTH
+    INTO createdUsercolumnLength
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE table_name = 'cf_AssetGroupDetails'
+    AND table_schema = 'pacmandata'
+    AND column_name = 'createdUser';
+
+    IF createdUsercolumnLength = 75 THEN
+        ALTER TABLE cf_AssetGroupDetails MODIFY COLUMN createdUser VARCHAR(200);
+    END IF;
+
+    SELECT CHARACTER_MAXIMUM_LENGTH
+    INTO modifiedUsercolumnLength
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE table_name = 'cf_AssetGroupDetails'
+    AND table_schema = 'pacmandata'
+    AND column_name = 'modifiedUser';
+
+    IF modifiedUsercolumnLength = 75 THEN
+        ALTER TABLE cf_AssetGroupDetails MODIFY COLUMN modifiedUser VARCHAR(200);
+    END IF;
+END $$
+DELIMITER ;
+CALL alter_cf_AssetGroupDetails_alter_user_length();


### PR DESCRIPTION
## Description

- Issue: creating asset group fails due to cf_AssetGroupDetails table createdUser and modifiedUser column length(75) and actual userName from cognito exceeds 75 chars
- increased the column length to 200

### Problem
actual userName from cognito exceeds 75 chars and table column length is only 75 chars

### Solution
increased the column length to 200

## Fixes # (issue if any)
column length of createdUser and modifiedUser column in cf_AssetGroupDetails

## Type of change

**Please delete options that are not relevant.**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Run the procedure and check the column length in db
- [ ] verify asset group creation is success using an AzureAD login which failed before

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
