### PR TITLE
fix:[CORE-1963] Fix filter api for asset group screen

### DIFF
--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/model/AssetGroupDetails.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/model/AssetGroupDetails.java
@@ -15,23 +15,14 @@
  ******************************************************************************/
 package com.tmobile.pacman.api.admin.repository.model;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.persistence.CascadeType;
-import java.sql.Timestamp;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
-
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
+import javax.persistence.*;
+import java.sql.Timestamp;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * AssetGroupDetails Model Class
@@ -55,6 +46,9 @@ public class AssetGroupDetails {
 	private String description;
 	private String aliasQuery;
 	private Boolean isVisible;
+
+	@Transient
+	private int totalCount;
 
 	@JsonManagedReference
 	@OneToMany(fetch = FetchType.LAZY, mappedBy = "assetGroup", cascade = CascadeType.ALL)
@@ -191,5 +185,13 @@ public class AssetGroupDetails {
 
 	public void setVisible(Boolean visible) {
 		isVisible = visible;
+	}
+
+	public int getTotalCount() {
+		return totalCount;
+	}
+
+	public void setTotalCount(int totalCount) {
+		this.totalCount = totalCount;
 	}
 }


### PR DESCRIPTION
## Description

- Issue: both asset group filter and list apis use common method with pagination, and issue is because size is set as 0 for the filter api flow(since we need the whole list without any pagination)
- Fix: apply pagination only if a size is specified

### Problem
both asset group filter and list apis use common method with pagination, and issue is because size is set as 0 for the filter api flow(since we need the whole list without any pagination)

### Solution
apply pagination only if a size is specified

## Fixes # (issue if any)
asset group filter api

## Type of change

**Please delete options that are not relevant.**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Verify asset group list API and test that asset groups are listed based on page numbers
- [ ] Verify asset group filter API and test with multiple filter combinations. Verify we get response based on filters applied

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
