### PR TITLE
fix/CORE-1976

### DIFF
--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/dao/RDSDBManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/dao/RDSDBManager.java
@@ -21,12 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.StringJoiner;
+import java.util.*;
 import java.sql.Date;
 
 public class RDSDBManager {
@@ -39,7 +34,7 @@ public class RDSDBManager {
     private static final String DB_URL = System.getProperty("spring.datasource.url");
     private static final String DB_USER_NAME = System.getProperty("spring.datasource.username");
     private static final String DB_PASSWORD = System.getProperty("spring.datasource.password");
-
+    private static  final Set<String> excludeStatusUpdate = new HashSet<>(Arrays.asList("checkmarx"));//Paladin  Controlling status for Checkmarx
     private RDSDBManager() {
     }
 
@@ -98,7 +93,7 @@ public class RDSDBManager {
         return 0;
     }
 
-    public static void insertNewPolicy(List<PolicyTable> policyList) {
+    public static void insertNewPolicy(String datasource,List<PolicyTable> policyList) {
         String strQuery = "INSERT INTO cf_PolicyTable (" +
                 "policyId, " +              // 1
                 "policyUUID, " +            // 2
@@ -128,10 +123,11 @@ public class RDSDBManager {
                 "policyType=VALUES(policyType), " +
                 "severity=VALUES(severity), " +
                 "category=VALUES(category), " +
-                "status=VALUES(status), " +
                 "policyFrequency=VALUES(policyFrequency), " +
                 "resolutionUrl=VALUES(resolutionUrl)";
-
+        if (!excludeStatusUpdate.contains(datasource.toLowerCase())) {
+            strQuery += ", status = VALUES(status)";
+        }
         String policyParams = "{\"params\":[{\"encrypt\":false,\"value\":\"%s\",\"key\":\"severity\"},"
                 + "{\"encrypt\":false,\"value\":\"%s\",\"key\":\"policyCategory\"}]}";
         String createDate = new SimpleDateFormat("yyyy-MM-dd").format(new java.util.Date());

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/dao/RDSDBManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/dao/RDSDBManager.java
@@ -131,7 +131,7 @@ public class RDSDBManager {
                 "policyFrequency=VALUES(policyFrequency), " +
                 "resolutionUrl=VALUES(resolutionUrl), "+
                 conditionalUpdateStatus
-               ;
+                ;
         String policyParams = "{\"params\":[{\"encrypt\":false,\"value\":\"%s\",\"key\":\"severity\"},"
                 + "{\"encrypt\":false,\"value\":\"%s\",\"key\":\"policyCategory\"}]}";
         String createDate = new SimpleDateFormat("yyyy-MM-dd").format(new java.util.Date());
@@ -167,10 +167,14 @@ public class RDSDBManager {
             LOGGER.error("Error Executing Query", ex);
         }
     }
-
+    /**
+     * Cache policies.
+     * This method caches the existing policies for the given datasource only once first time at initial execution
+     * @param datasource the datasource
+     */
     private static void cachePolicies(String datasource) {
-     List<String> policyIds =   executeStringQuery("SELECT policyId FROM cf_PolicyTable WHERE assetGroup = '" + datasource + "'");
-     policyIds.stream().forEach(policyId -> policyIdsSet.add(policyId));
+        List<String> policyIds =   executeStringQuery("SELECT policyId FROM cf_PolicyTable WHERE assetGroup = '" + datasource + "'");
+        policyIds.stream().forEach(policyId -> policyIdsSet.add(policyId));
     }
 
     public static List<String> executeStringQuery(String query) {
@@ -239,13 +243,13 @@ public class RDSDBManager {
      * @return
      */
     private static String determinePolicyStatus(PolicyTable policy, boolean isPluginAlreadyExists) {
-        if (!StringUtils.isNullOrEmpty(policy.getStatus())) { //Case 1 : When Policy has Status (Contrast) use that
+        if (!StringUtils.isNullOrEmpty(policy.getStatus())) { //Case 1 : When Policy has Status  use that
             return policy.getStatus();
         }
-        if (isPluginAlreadyExists) { //Case 2 : When Policy Status is NULL (Checkmarx/Wiz) and Plugin Already Exists
+        if (isPluginAlreadyExists) { //Case 2 : When Policy Status is NULL  and Plugin Already Exists
             return isPolicyNew(policy) ? "DISABLED" : "";//Case 2.a : If Policy is new, set status to "DISABLED".Else IGNORE
         }
-        return "ENABLED";   //Case 3 : When Policy Status is NULL (Checkmarx/Wiz) and Plugin is being executed for the first time
+        return "ENABLED";   //Case 3 : When Policy Status is NULL and Plugin is being executed for the first time
     }
 
     public static boolean isPolicyNew(PolicyTable policy) {

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/dao/RDSDBManager.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/dao/RDSDBManager.java
@@ -237,7 +237,7 @@ public class RDSDBManager {
     }
 
     public static boolean isPolicyNew(PolicyTable policy) {
-        return policyIdsSet.contains(policy.getPolicyId());
+        return !policyIdsSet.contains(policy.getPolicyId());
     }
 
     private static int executeCountQuery(PreparedStatement preparedStatement) throws SQLException {

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ExternalPolicies.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ExternalPolicies.java
@@ -88,7 +88,7 @@ public class ExternalPolicies {
                 policyList.add(policy);
             }
 
-            RDSDBManager.insertNewPolicy(policyList);
+            RDSDBManager.insertNewPolicy(dataSource,policyList);
         } catch (Exception e) {
             LOGGER.error("policy upload exception", e);
         }

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ExternalPolicies.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/entity/ExternalPolicies.java
@@ -88,7 +88,7 @@ public class ExternalPolicies {
                 policyList.add(policy);
             }
 
-            RDSDBManager.insertNewPolicy(dataSource,policyList);
+            RDSDBManager.insertNewPolicy(dataSource, policyList);
         } catch (Exception e) {
             LOGGER.error("policy upload exception", e);
         }


### PR DESCRIPTION
**Various Use Cases covered under this PR**
**Case 1** : When Policy has inComingStatus (ex Contrast) use that for Insert/Update to status field in cf_policy table
**Case 2** :  When Policy Status is NULL (Checkmarx/Wiz) and Plugin has been executed before
    Case 2.a : If Policy is new, set status to "DISABLED"  else ignore UPDATE 
Case 3 :When Policy Status is NULL (Checkmarx/Wiz) and Plugin is being executed for the first time status should be "**ENABLED**"

**Performance considerations**
_For better performance consideration i have cached policyIds and check against cache to check whether particular policy is new or not_

### Problem
In Shipper we have condition if policyID already exists we are updating the status every time shipper runs. That is root cause of the problem

### Solution
For Checkmarx, Status are controlled by Paladin, we should skip the update when shipper runs next time.
![image](https://github.com/PaladinCloud/CE/assets/138756904/3efa7bfc-fd00-46dd-ab2d-9432961c4ae9)

## Fixes # (issue if any)
Shipper code change
## Type of change

**Please delete options that are not relevant.**

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration


**Use Case 1 : Plugin does not have status like Checkmarx,Wiz**

1.a) When first time Checkmarx Plugin gets added
Expected policy count is 0 (initial State)
![image](https://github.com/PaladinCloud/CE/assets/138756904/bed680d5-4432-413d-b7f1-c83b9c469bae)


1.b) After policy gets inserted (plugin post addition)
Expected policy count > 0 with status = ‘ENABLED”
![image](https://github.com/PaladinCloud/CE/assets/138756904/afc2fdad-af2f-4ea7-9cf2-71dafb04b43b)



1.c) Shipper run again 
Expected status = “ENABLED” status quo should be maintained
![image](https://github.com/PaladinCloud/CE/assets/138756904/2ba894ec-e52e-41a1-be0c-2116ef33f734)



**Use Case 2 :  when Plugin Policy has status -Contrast**
Insert/update should happen with Incoming status value from API

Contrast Shipper run (initial State)
![image](https://github.com/PaladinCloud/CE/assets/138756904/476bcedd-f454-43dc-94c2-4efc75dc3574)


Rerunning shipper (Should update incoming status)
![image](https://github.com/PaladinCloud/CE/assets/138756904/56ec418f-57ba-4ccb-a356-b6f90e0127a8)




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
