### PR TITLE
fix:[CORE-1898] Fix colliding asset type names

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -3344,3 +3344,5 @@ BEGIN
 END $$
 DELIMITER ;
 CALL alter_cf_AssetGroupDetails_alter_user_length();
+
+UPDATE cf_Target SET displayName='PostgreSQL' WHERE targetName in ('cloudsql_postgres','postgresql');


### PR DESCRIPTION
## Description

- issue: asset types gcp_cloudsql_postgres and azure_postgresql have colliding names "PostgreSQL" and "Postgre SQL"
- solution: gcp_cloudsql_postgres and azure_postgresql must have same displayName so that they are displayed under a single display name on the UI.

### Problem
asset types gcp_cloudsql_postgres and azure_postgresql have colliding names

### Solution
Give same displayName to asset types gcp_cloudsql_postgres and azure_postgresql

## Fixes # (issue if any)
displayName of asset types

## Type of change

**Please delete options that are not relevant.**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Run the db script.
- [ ] Run the collector, shipper for gcp and azure
- [ ] run the policy rules for all the policies related to gcp_cloudsql_postgres and azure_postgresql
- [ ] verify policy display name of the assets and policies for gcp_cloudsql_postgres and azure_postgresql on UI

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
