### PR TITLE
fix:[CUS-286] Fix dips in collected snapshot assets for vertex

### DIFF
--- a/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/util/InventoryUtil.java
+++ b/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/util/InventoryUtil.java
@@ -1970,8 +1970,8 @@ public class InventoryUtil {
                             .describeSnapshots(new DescribeSnapshotsRequest().withOwnerIds(accountId)).getSnapshots();
                     if (!snapShotsList.isEmpty()) {
                         List<SnapshotVH> snapShotVHList = snapShotsList.stream()
-                                .map(snapshot -> new SnapshotVH(snapshot,
-                                        getSnapShotPermissions(ec2Client, snapshot.getSnapshotId())))
+                                .map(snapshot -> buildSnapshotVH(ec2Client, snapshot))
+                                .filter(Objects::nonNull)
                                 .collect(Collectors.toList());
 
                         log.debug(InventoryConstants.ACCOUNT + accountId + " Type : Snapshot " + region.getName()
@@ -1993,17 +1993,26 @@ public class InventoryUtil {
      * Get SnapShot permission.
      *
      * @param ec2Client  the AmazonEC2
-     * @param snapshotID the SnapShot ID
+     * @param snapshot the SnapShot
      * @return the boolean
      */
-    private static boolean getSnapShotPermissions(AmazonEC2 ec2Client, String snapshotID) {
-        DescribeSnapshotAttributeResult describeSnapshotAttribute = ec2Client
-                .describeSnapshotAttribute(new DescribeSnapshotAttributeRequest().withSnapshotId(snapshotID)
-                        .withAttribute(SnapshotAttributeName.CreateVolumePermission));
-        List<CreateVolumePermission> createVolumePermissions = describeSnapshotAttribute.getCreateVolumePermissions();
-        boolean ispublic = createVolumePermissions.stream()
-                .anyMatch(volPerm -> volPerm.getGroup() != null && "all".equalsIgnoreCase(volPerm.getGroup()));
-        return ispublic;
+    private static SnapshotVH buildSnapshotVH(AmazonEC2 ec2Client, Snapshot snapshot) {
+        try {
+            DescribeSnapshotAttributeResult describeSnapshotAttribute = ec2Client
+                    .describeSnapshotAttribute(new DescribeSnapshotAttributeRequest().withSnapshotId(snapshot.getSnapshotId())
+                            .withAttribute(SnapshotAttributeName.CreateVolumePermission));
+            List<CreateVolumePermission> createVolumePermissions = describeSnapshotAttribute.getCreateVolumePermissions();
+            boolean isPublic = createVolumePermissions.stream()
+                    .anyMatch(volPerm -> volPerm.getGroup() != null && "all".equalsIgnoreCase(volPerm.getGroup()));
+            return new SnapshotVH(snapshot, isPublic);
+        } catch (AmazonEC2Exception e) {
+            if ("InvalidSnapshot.NotFound".equalsIgnoreCase(e.getErrorCode())) {
+                log.info("Snapshot Not found. Unable to describe snapshot with ID " + snapshot.getSnapshotId());
+            } else {
+                throw e;
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Description

- issue: the issue is in the way we collect and describe snapshots in the collector. The collector seems to skip collecting if its not able to find and describe a snapshot id that it had listed
- in this case, the snapshot could not be found using snapshotID
- fix: handle exception during describing individual snapshots, so that it doesn't stop describing other listed snapshots
- handled the case when snapshot could not be found using snapshotID

### Problem
collector skips collecting snapshot if there is an issue describing a single snapshot

### Solution
handle exception for individual snapshots

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Replicate the issue by hardcoding an invalid snapshotID
- [ ] Verify the other snapshots are collected

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
