### PR TITLE
fix:[CORE-2024] scheduler fix

### DIFF
--- a/jobs/job-scheduler/src/main/java/com/paladincloud/jobscheduler/service/JobScheduler.java
+++ b/jobs/job-scheduler/src/main/java/com/paladincloud/jobscheduler/service/JobScheduler.java
@@ -117,8 +117,8 @@ public class JobScheduler {
 
         try {
             ConfigUtil.setConfigProperties();
-            azureEnabled = Boolean.parseBoolean(System.getProperty(AZURE_ENABLED));
-            awsEnabled = Boolean.parseBoolean(System.getProperty(AWS_ENABLED));
+            azureEnabled = Boolean.parseBoolean(env.getProperty(AZURE_ENABLED));
+            awsEnabled = Boolean.parseBoolean(env.getProperty(AWS_ENABLED));
             boolean compositePluginEnabled = isCompositeEnabled();
             if (!compositePluginEnabled && awsEnabled) {
                 addCollectorEvent(putEventsRequestEntries, awsBusDetails);
@@ -202,9 +202,9 @@ public class JobScheduler {
         try {
             ConfigUtil.setConfigProperties();
 
-            qualysEnabled=Boolean.parseBoolean(System.getProperty(QUALYS_ENABLED));
-            aquaEnabled=Boolean.parseBoolean(System.getProperty(AQUA_ENABLED));
-            tenableEnabled=Boolean.parseBoolean(System.getProperty(TENABLE_ENABLED));
+            qualysEnabled=Boolean.parseBoolean(env.getProperty(QUALYS_ENABLED));
+            aquaEnabled=Boolean.parseBoolean(env.getProperty(AQUA_ENABLED));
+            tenableEnabled=Boolean.parseBoolean(env.getProperty(TENABLE_ENABLED));
             if (qualysEnabled) {
                 addPluginCollectorEvent(putEventsRequestEntries, vulnerabilityBusDetails, PLUGIN_TYPE_QUALYS);
             }


### PR DESCRIPTION
[CORE-2024]

## Description
Our config url is not  able to fetch “application” properties
CONFIG_URL=[https://saasqa.paladincloud.io/api/config/application,batch,inventory,job-scheduler/prd/latest](https://saasqa.paladincloud.io/api/config/batch,inventory,job-scheduler/prd/latest)

during the release of v1.90, we changed the type of application to “application” from “job-scheduler” for aws.enabled, azure.enabled, etc

we made the because, it was necessary to make it available to api-services

### Problem

### Solution


## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


[CORE-2024]: https://paladincloud.atlassian.net/browse/CORE-2024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ