### PR TITLE
fix:[UIUX-685] selector label text lowercase

### DIFF
--- a/webapp/src/app/pacman-features/modules/compliance/issue-details/issue-details.component.css
+++ b/webapp/src/app/pacman-features/modules/compliance/issue-details/issue-details.component.css
@@ -26,7 +26,7 @@
 }
 
 .tile-content-wrapper {
-    padding: 20px 20px 20px 24px;
+    padding: 20px 0px 20px 24px;
     background: var(--background-white);
     border-right: 1px solid var(--border-100);
 }

--- a/webapp/src/app/pacman-features/modules/compliance/issue-details/issue-details.component.css
+++ b/webapp/src/app/pacman-features/modules/compliance/issue-details/issue-details.component.css
@@ -26,7 +26,7 @@
 }
 
 .tile-content-wrapper {
-    padding: 20px 0px 20px 24px;
+    padding: 20px 20px 20px 24px;
     background: var(--background-white);
     border-right: 1px solid var(--border-100);
 }

--- a/webapp/src/app/post-login-app/asset-groups/asset-groups.component.html
+++ b/webapp/src/app/post-login-app/asset-groups/asset-groups.component.html
@@ -19,7 +19,7 @@
                     <div *ngFor="let assetTabName of assetTabNames; let i = index">
                         <div
                             [class.active]="selectedTabName == assetTabName"
-                            class="asset-group-tab"
+                            class="asset-group-tab capitalize"
                             (click)="tabsClicked(assetTabName)"
                         >
                             {{ assetTabName }}


### PR DESCRIPTION
## Description

https://paladincloud.atlassian.net/browse/UIUX-685

The Asset Group Selector category text is in lowercase; it should be capitalized.

### Problem

<img width="1645" alt="Screenshot 2024-05-14 at 1 52 39 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/b39c3d2d-4874-41ff-80dd-614c9f9f4721">

<img width="1645" alt="Screenshot 2024-05-14 at 1 50 48 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/d920cc2c-7f84-4f79-96c0-e50eceae1db7">

### Solution

Added a CSS class to handle label capitalization.

<img width="851" alt="Screenshot 2024-05-14 at 11 44 35 AM" src="https://github.com/PaladinCloud/CE/assets/152586069/69425302-cffa-414a-8f20-e3b2541e067d">

## Type of change

**Please delete options that are not relevant.**

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
