### PR TITLE
fix:[UIUX-693] asset trend graph min round off value fix

### DIFF
--- a/webapp/src/app/shared/multiline-zoom-graph/multiline-zoom-graph.component.ts
+++ b/webapp/src/app/shared/multiline-zoom-graph/multiline-zoom-graph.component.ts
@@ -429,10 +429,8 @@ export class MultilineZoomGraphComponent implements AfterViewInit, OnChanges {
     // rounds off to nearest multiple of roundOffToVal bounding up to valToRoundOff
     roundOff(valToRoundOff, roundOffToVal, max = true) {
         if (roundOffToVal < 0 || valToRoundOff === 0) return 0;
-
-        const calc = (valToRoundOff / roundOffToVal) * roundOffToVal;
-        if (max) return Math.ceil(calc);
-        else return Math.floor(calc);
+        if (max) return Math.ceil(valToRoundOff / roundOffToVal) * roundOffToVal;
+        else return Math.floor(valToRoundOff / roundOffToVal) * roundOffToVal;
     }
 
     getNearestPowerOf10(val, offSet = 0) {

--- a/webapp/src/app/shared/multiline-zoom-graph/multiline-zoom-graph.component.ts
+++ b/webapp/src/app/shared/multiline-zoom-graph/multiline-zoom-graph.component.ts
@@ -427,12 +427,12 @@ export class MultilineZoomGraphComponent implements AfterViewInit, OnChanges {
     }
 
     // rounds off to nearest multiple of roundOffToVal bounding up to valToRoundOff
-    roundOff(valToRoundOff, roundOffToVal) {
-        if (roundOffToVal > 0) {
-            return Math.ceil(valToRoundOff / roundOffToVal) * roundOffToVal;
-        } else {
-            return 0;
-        }
+    roundOff(valToRoundOff, roundOffToVal, max = true) {
+        if (roundOffToVal < 0 || valToRoundOff === 0) return 0;
+
+        const calc = (valToRoundOff / roundOffToVal) * roundOffToVal;
+        if (max) return Math.ceil(calc);
+        else return Math.floor(calc);
     }
 
     getNearestPowerOf10(val, offSet = 0) {
@@ -454,7 +454,7 @@ export class MultilineZoomGraphComponent implements AfterViewInit, OnChanges {
                 roundOffMultiple *
                 this.getNearestPowerOf10(this.axisMaxValue - this.axisMinValue, 1);
             // we need floor of val to get tickVal below minVal, minval should be rounded off to nearest roundOffToVal
-            const yMin = this.roundOff(this.axisMinValue - roundOffToVal, roundOffToVal); // we remove roundOffToVal from axisMinValue to get floor value since roundOff function returns ceil val
+            const yMin = this.roundOff(this.axisMinValue, roundOffToVal, false);
             const yMax = this.roundOff(this.axisMaxValue, roundOffToVal);
             let y = this.roundOff(
                 Math.ceil((yMax - yMin) / (maxNumberOfTickValues - 1)),


### PR DESCRIPTION
## Description

https://paladincloud.atlassian.net/browse/UIUX-693

Asset Trend graph showing negative yAxis value.

### Problem
<img width="1662" alt="Screenshot 2024-05-20 at 4 08 06 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/fd6410be-6886-43df-8a98-917966bf9793">

## Fixe
<img width="1662" alt="Screenshot 2024-05-20 at 4 03 22 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/5a253b9d-8804-48b2-9b7e-5596b39c2b23">

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Unit Testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
