### PR TITLE
Filter out polices with no matching violations

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
@@ -91,7 +91,6 @@ public class AssetTypeGroupedVulnerabilitiesRule extends BasePolicy {
             if (!CollectionUtils.isNullOrEmpty(vulnerabilityInfoList)) {
                 String vulnerabilityDetails = getVMVulnerabilityDetails(vulnerabilityInfoList, severity);
                 if (!vulnerabilityDetails.equals("[]")) {
-
                     Annotation annotation = Annotation.buildAnnotation(ruleParam, Annotation.Type.ISSUE);
                     annotation.put(PacmanSdkConstants.DESCRIPTION, "VM Instance with " + severity + " vulnerabilities found");
                     annotation.put(PacmanRuleConstants.SEVERITY, severity);

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
@@ -87,16 +87,22 @@ public class AssetTypeGroupedVulnerabilitiesRule extends BasePolicy {
                 logger.error("unable to determine", e);
                 throw new RuleExecutionFailedExeption("unable to determine" + e);
             }
-            if (!CollectionUtils.isNullOrEmpty(vulnerabilityInfoList)) {
-                Annotation annotation = Annotation.buildAnnotation(ruleParam, Annotation.Type.ISSUE);
-                annotation.put(PacmanSdkConstants.DESCRIPTION, "VM Instance with " + severity + " vulnerabilities found");
-                annotation.put(PacmanRuleConstants.SEVERITY, severity);
-                annotation.put(PacmanRuleConstants.CATEGORY, category);
-                String vulnerabilityDetails = getVMVulnerabilityDetails(vulnerabilityInfoList, severity);
-                annotation.put("vulnerabilityDetails", vulnerabilityDetails);
 
-                policyResult = new PolicyResult(PacmanSdkConstants.STATUS_FAILURE, PacmanRuleConstants.FAILURE_MESSAGE, annotation);
-            } else {
+            if (!CollectionUtils.isNullOrEmpty(vulnerabilityInfoList)) {
+                String vulnerabilityDetails = getVMVulnerabilityDetails(vulnerabilityInfoList, severity);
+                if (!vulnerabilityDetails.equals("[]")) {
+
+                    Annotation annotation = Annotation.buildAnnotation(ruleParam, Annotation.Type.ISSUE);
+                    annotation.put(PacmanSdkConstants.DESCRIPTION, "VM Instance with " + severity + " vulnerabilities found");
+                    annotation.put(PacmanRuleConstants.SEVERITY, severity);
+                    annotation.put(PacmanRuleConstants.CATEGORY, category);
+                    annotation.put("vulnerabilityDetails", vulnerabilityDetails);
+
+                    policyResult = new PolicyResult(PacmanSdkConstants.STATUS_FAILURE, PacmanRuleConstants.FAILURE_MESSAGE, annotation);
+                }
+            }
+
+            if (policyResult == null) {
                 policyResult = new PolicyResult(PacmanSdkConstants.STATUS_SUCCESS, PacmanRuleConstants.SUCCESS_MESSAGE);
             }
         }


### PR DESCRIPTION
## Description

The Rapid7 'medium' severity policy was showing as having failed when it was empty (there were no associated CVE's). This filters empty CVE's out which results in the 'medium' policy as succeeding.

## Fixes # (issue if any)
PLG-534

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] added a unit test

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] My commit message/PR follows the contribution guidelines of this project
- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes

