### PR TITLE
fix:[PLG-564] CS-Group CVEs based on app/product in violation info

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/constants/PacmanRuleConstants.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/constants/PacmanRuleConstants.java
@@ -689,5 +689,8 @@ public class PacmanRuleConstants {
     public static final String LATEST_CLOUD_WATCH_DELIVERY_TIME="latestCloudWatchLogsDeliveryTime";
     public static final String SERVICE = "Service";
     public static final String REGION_GLOBAL = "global";
-  public static final String ACCOUNT_ID = "accountid";
+    public static final String ACCOUNT_ID = "accountid";
+    public static final String PRODUCT_NAME_VERSION = "product_name_version";
+    public static final String PRODUCT_NAME_NORMALIZED = "product_name_normalized";
+    public static final String CVE_ID = "cveId";
 }

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/crowdstrike/VulnerabilityAssessmentPolicy.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/crowdstrike/VulnerabilityAssessmentPolicy.java
@@ -52,7 +52,7 @@ public class VulnerabilityAssessmentPolicy extends BasePolicy {
             try {
                 JsonArray severityList = PacmanUtils.getVulnerabilitiesArray(severityToCheck, instanceId, esIndexUrl);
                 if (severityList != null && !severityList.isEmpty()) {
-                    String severityDetails = PacmanUtils.getCrowdstrikeVulnerabilitiesDetails(severityList);
+                    String severityDetails = PacmanUtils.getVulnerabilitiesDetails(severityList);
                     annotation = Annotation.buildAnnotation(policyParam, Annotation.Type.ISSUE);
                     annotation.put(PacmanSdkConstants.DESCRIPTION, "An Ec2 instance with " + severity + " vulnerability found!!");
                     annotation.put(PacmanRuleConstants.SEVERITY, severity);

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -145,6 +145,7 @@ public class PolicyExecutor {
         try {
             String jsonResponse = CommonUtils.doHttpPost(policyDetailsUrl, requestJson);
             policyWiseParamsList = convertJsonToListOfMap(jsonResponse);
+            logger.debug("Found {} policies to evaluate", policyWiseParamsList.size());
         } catch (Exception e) {
             logger.error("failed in getting Policy list for {}", requestJson, e);
         }


### PR DESCRIPTION
## Description

- group cves based on product/app for crowdstrike violations instead of showing description for each cve
- Vulnerability url will now deep link to the falcon vulnerability page filtered on the product/app 

### Problem

### Solution


## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Run the mapper and shipper with the fixes
- [ ] verify CVEs are grouped by app in vulnerability info 
- [ ] verify vulnerability url deep links to the falcon vulnerability page filtered on the product/app 

![image](https://github.com/PaladinCloud/CE/assets/149176078/fff5edd7-0785-4109-8eaf-a94d7bcbccd0)
![image](https://github.com/PaladinCloud/CE/assets/149176078/0b1947a3-83d8-479e-b4ea-4c0e81536d49)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki
