### PR TITLE
fix:[UIUX-669] fixed text transformation of asset group types

### DIFF
--- a/webapp/src/app/post-login-app/asset-groups/asset-groups.component.html
+++ b/webapp/src/app/post-login-app/asset-groups/asset-groups.component.html
@@ -19,7 +19,7 @@
                     <div *ngFor="let assetTabName of assetTabNames; let i = index">
                         <div
                             [class.active]="selectedTabName == assetTabName"
-                            class="asset-group-tab capitalize"
+                            class="asset-group-tab"
                             (click)="tabsClicked(assetTabName)"
                         >
                             {{ assetTabName }}
@@ -56,10 +56,7 @@
                                 class="asset-group-list-item"
                                 [class.active]="currentAssetTile == assettile.name.toLowerCase()"
                             >
-                                <div
-                                    class="asset-tile-name"
-                                    [ngStyle]="{ 'text-transform': 'capitalize' }"
-                                >
+                                <div class="asset-tile-name">
                                     {{ getDisplayName(assettile.displayname) }}
                                 </div>
                             </div>


### PR DESCRIPTION
## Description

https://paladincloud.atlassian.net/browse/UIUX-669
Remove the text transformation for asset group type (removes capitalization of the first character).

### Problem

<img width="1028" alt="Screenshot 2024-05-30 at 9 54 04 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/3cb702a6-220c-4a32-b70b-a6042573ef74">

## Fixes

<img width="1066" alt="Screenshot 2024-05-30 at 9 54 49 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/f7476229-30c6-48db-b451-1a416e72e52c">

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Unit testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed text capitalization from asset group tabs and asset tile names for a more consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->