### PR TITLE
fix:[CORE-2047]Policy Failure fix

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/VirtualMachine/BYOKDiskVolumeRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/VirtualMachine/BYOKDiskVolumeRule.java
@@ -106,8 +106,15 @@ public class BYOKDiskVolumeRule extends BasePolicy {
                 JsonObject jsonDataItem = (JsonObject) ((JsonObject) hitsJsonArray.get(0))
                         .get(PacmanRuleConstants.SOURCE);
                 logger.debug("Validating the data item: {}", jsonDataItem.toString());
-                JsonArray diskJsonArray = jsonDataItem.getAsJsonObject()
-                        .get(PacmanRuleConstants.DISKS).getAsJsonArray();
+                JsonArray diskJsonArray = null;
+
+                if (jsonDataItem != null && jsonDataItem.isJsonObject()) {
+                    JsonObject jsonObject = jsonDataItem.getAsJsonObject();
+
+                    if (jsonObject.has(PacmanRuleConstants.DISKS) && jsonObject.get(PacmanRuleConstants.DISKS).isJsonArray()) {
+                        diskJsonArray = jsonObject.get(PacmanRuleConstants.DISKS).getAsJsonArray();
+                    }
+                }
                 if(diskJsonArray.size()>0) {
                     for (int i = 0; i < diskJsonArray.size(); i++) {
                         JsonObject diskDataItem = ((JsonObject) diskJsonArray

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/VirtualMachine/BYOKDiskVolumeRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/VirtualMachine/BYOKDiskVolumeRule.java
@@ -115,7 +115,7 @@ public class BYOKDiskVolumeRule extends BasePolicy {
                         diskJsonArray = jsonObject.get(PacmanRuleConstants.DISKS).getAsJsonArray();
                     }
                 }
-                if(diskJsonArray.size()>0) {
+                if(diskJsonArray!=null && diskJsonArray.size()>0) {
                     for (int i = 0; i < diskJsonArray.size(); i++) {
                         JsonObject diskDataItem = ((JsonObject) diskJsonArray
                                 .get(i));

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/VirtualMachine/EncryptionAppTierRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/VirtualMachine/EncryptionAppTierRule.java
@@ -107,7 +107,7 @@ public class EncryptionAppTierRule extends BasePolicy {
                         diskJsonArray = jsonObject.get(PacmanRuleConstants.DISKS).getAsJsonArray();
                     }
                 }
-                if(diskJsonArray.size()>0) {
+                if(diskJsonArray!=null && diskJsonArray.size()>0) {
                     for (int i = 0; i < diskJsonArray.size(); i++) {
                         JsonObject diskDataItem = ((JsonObject) diskJsonArray
                                 .get(i));

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/VirtualMachine/EncryptionAppTierRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/VirtualMachine/EncryptionAppTierRule.java
@@ -98,8 +98,15 @@ public class EncryptionAppTierRule extends BasePolicy {
                 JsonObject jsonDataItem = (JsonObject) ((JsonObject) hitsJsonArray.get(0))
                         .get(PacmanRuleConstants.SOURCE);
                 logger.debug("Validating the data item: {}", jsonDataItem.toString());
-                JsonArray diskJsonArray = jsonDataItem.getAsJsonObject()
-                        .get(PacmanRuleConstants.DISKS).getAsJsonArray();
+                JsonArray diskJsonArray = null;
+
+                if (jsonDataItem != null && jsonDataItem.isJsonObject()) {
+                    JsonObject jsonObject = jsonDataItem.getAsJsonObject();
+
+                    if (jsonObject.has(PacmanRuleConstants.DISKS) && jsonObject.get(PacmanRuleConstants.DISKS).isJsonArray()) {
+                        diskJsonArray = jsonObject.get(PacmanRuleConstants.DISKS).getAsJsonArray();
+                    }
+                }
                 if(diskJsonArray.size()>0) {
                     for (int i = 0; i < diskJsonArray.size(); i++) {
                         JsonObject diskDataItem = ((JsonObject) diskJsonArray


### PR DESCRIPTION
## Description

At saasqa "policy-engine-azure-virtualmachine" got failed due to NULL pointer exception caused when it tries to access VM disks.
**PolicyIds : "azure_DiskEncryption_virtualmachine","azure_Enable_VM_disk_Volumes_Encrypted","Enable_Virtual_Machine_Disk_Volume_Customer_Managed_Key"**


### Problem
NULL pointer exception
### Solution
Handling NPE

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation logic to handle potential null pointer exceptions when accessing disk information.
	- Enhanced handling of disk data to ensure proper validation of customer-managed key attachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->