### PR TITLE
Handle the case of a missing CVE id

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
@@ -19,6 +19,7 @@ import com.amazonaws.util.CollectionUtils;
 import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.tmobile.cloud.awsrules.utils.PacmanUtils;
@@ -118,8 +119,17 @@ public class AssetTypeGroupedVulnerabilitiesRule extends BasePolicy {
         for (JsonObject vulnerability : vulnerabilityInfoList) {
             for (JsonElement cveDetails : vulnerability.get(severity).getAsJsonArray()) {
                 VulnerabilityInfo vul = new VulnerabilityInfo();
-                String cveId = cveDetails.getAsJsonObject().get("id").getAsString();
-                CveDetails cve = new CveDetails(cveId, PacmanUtils.NIST_VULN_DETAILS_URL + cveId);
+                JsonElement cveIdElement = cveDetails.getAsJsonObject().get("id");
+                String cveUrl;
+                String cveId;
+                if (Strings.isNullOrEmpty(cveIdElement.getAsString())) {
+                    cveUrl = cveDetails.getAsJsonObject().get("cveUrl").getAsString();
+                    cveId = "";
+                } else {
+                    cveUrl = PacmanUtils.NIST_VULN_DETAILS_URL + cveIdElement.getAsString();
+                    cveId = cveIdElement.getAsString();
+                }
+                CveDetails cve = new CveDetails(cveId, cveUrl);
                 List<CveDetails> cveList = new ArrayList<>();
                 cveList.add(cve);
                 vul.setCveList(cveList);

--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
@@ -119,17 +119,15 @@ public class AssetTypeGroupedVulnerabilitiesRule extends BasePolicy {
         for (JsonObject vulnerability : vulnerabilityInfoList) {
             for (JsonElement cveDetails : vulnerability.get(severity).getAsJsonArray()) {
                 VulnerabilityInfo vul = new VulnerabilityInfo();
-                JsonElement cveIdElement = cveDetails.getAsJsonObject().get("id");
-                String cveUrl;
-                String cveId;
-                if (Strings.isNullOrEmpty(cveIdElement.getAsString())) {
-                    cveUrl = cveDetails.getAsJsonObject().get("cveUrl").getAsString();
-                    cveId = "";
-                } else {
-                    cveUrl = PacmanUtils.NIST_VULN_DETAILS_URL + cveIdElement.getAsString();
-                    cveId = cveIdElement.getAsString();
+                String cveId = cveDetails.getAsJsonObject().get("id").getAsString();
+                String vulnerabilityUrl = null;
+                if (cveDetails.getAsJsonObject().has("vulnerabilityUrl")) {
+                    vulnerabilityUrl = cveDetails.getAsJsonObject().get("vulnerabilityUrl").getAsString();
                 }
-                CveDetails cve = new CveDetails(cveId, cveUrl);
+                if (Strings.isNullOrEmpty(vulnerabilityUrl)) {
+                    vulnerabilityUrl = PacmanUtils.NIST_VULN_DETAILS_URL + cveId;
+                }
+                CveDetails cve = new CveDetails(cveId, vulnerabilityUrl);
                 List<CveDetails> cveList = new ArrayList<>();
                 cveList.add(cve);
                 vul.setCveList(cveList);

--- a/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRuleTest.java
+++ b/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRuleTest.java
@@ -32,7 +32,7 @@ public class AssetTypeGroupedVulnerabilitiesRuleTest {
     public void correctlyProcessCritical() throws Exception {
         mockStatic(PacmanUtils.class);
         when(PacmanUtils.doesAllHaveValue(anyString(), anyString())).thenReturn(true);
-        String vulnerabilities = "{ \"instanceId\": \"iid-1\", \"critical\": [ { \"id\": \"CVE-2024-29986\", \"severity\": \"severe\", \"title\": \"Microsoft Edge Chromium: CVE-2024-29986\", \"url\": \"https://example.com/microsoft-edge-cve-2024-29986/\" }, { \"id\": \"CVE-2024-29987\", \"severity\": \"severe\", \"title\": \"Microsoft Edge Chromium: CVE-2024-29987\", \"url\": \"https://example.com/microsoft-edge-cve-2024-29987/\" } ] }";
+        String vulnerabilities = "{\"instanceId\":\"iid-1\",\"critical\":[{\"id\":\"CVE-2024-29986\",\"severity\":\"severe\",\"title\":\"Microsoft Edge Chromium: CVE-2024-29986\",\"url\":\"https://example.com/microsoft-edge-cve-2024-29986/\"},{\"id\":\"\",\"severity\":\"severe\",\"title\":\"Weak LAN Manager hashing permitted\",\"url\":\"https://example.com/weak-lan-manager-hashing-permitted\",\"cveUrl\":\"https://support.microsoft.com/en-us/help/2793313/security-guidance-for-ntlmv1-and-lm-network-authentication\"}]}";
         when(PacmanUtils.matchAssetAgainstSourceVulnIndex(anyString(), anyString(), anyString(), anyObject())).thenReturn(convertVulnerabilities(vulnerabilities));
         PolicyResult result = assetTypeGroupedVulnerabilitiesRule.execute(getRuleParams("critical"), getResourceAttributes());
         assertThat(result, is(notNullValue()));
@@ -70,10 +70,10 @@ public class AssetTypeGroupedVulnerabilitiesRuleTest {
         v[0].setVulnerabilityUrl("https://example.com/microsoft-edge-cve-2024-29986/");
         v[0].setCveList(Arrays.asList(cveList1));
 
-        CveDetails[] cveList2 = {new CveDetails("CVE-2024-29987", "https://nvd.nist.gov/vuln/detail/CVE-2024-29987")};
+        CveDetails[] cveList2 = {new CveDetails("", "https://support.microsoft.com/en-us/help/2793313/security-guidance-for-ntlmv1-and-lm-network-authentication")};
         v[1] = new VulnerabilityInfo();
-        v[1].setTitle("Microsoft Edge Chromium: CVE-2024-29987");
-        v[1].setVulnerabilityUrl("https://example.com/microsoft-edge-cve-2024-29987/");
+        v[1].setTitle("Weak LAN Manager hashing permitted");
+        v[1].setVulnerabilityUrl("https://example.com/weak-lan-manager-hashing-permitted/");
         v[1].setCveList(Arrays.asList(cveList2));
         return v;
     }

--- a/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRuleTest.java
+++ b/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRuleTest.java
@@ -32,7 +32,7 @@ public class AssetTypeGroupedVulnerabilitiesRuleTest {
     public void correctlyProcessCritical() throws Exception {
         mockStatic(PacmanUtils.class);
         when(PacmanUtils.doesAllHaveValue(anyString(), anyString())).thenReturn(true);
-        String vulnerabilities = "{\"instanceId\":\"iid-1\",\"critical\":[{\"id\":\"CVE-2024-29986\",\"severity\":\"severe\",\"title\":\"Microsoft Edge Chromium: CVE-2024-29986\",\"url\":\"https://example.com/microsoft-edge-cve-2024-29986/\"},{\"id\":\"\",\"severity\":\"severe\",\"title\":\"Weak LAN Manager hashing permitted\",\"url\":\"https://example.com/weak-lan-manager-hashing-permitted\",\"cveUrl\":\"https://support.microsoft.com/en-us/help/2793313/security-guidance-for-ntlmv1-and-lm-network-authentication\"}]}";
+        String vulnerabilities = "{\"instanceId\":\"iid-1\",\"critical\":[{\"id\":\"CVE-2024-29986\",\"severity\":\"severe\",\"title\":\"Microsoft Edge Chromium: CVE-2024-29986\",\"url\":\"https://example.com/microsoft-edge-cve-2024-29986/\"},{\"id\":\"\",\"severity\":\"severe\",\"title\":\"Weak LAN Manager hashing permitted\",\"url\":\"https://example.com/weak-lan-manager-hashing-permitted\",\"vulnerabilityUrl\":\"https://support.microsoft.com/en-us/help/2793313/security-guidance-for-ntlmv1-and-lm-network-authentication\"}]}";
         when(PacmanUtils.matchAssetAgainstSourceVulnIndex(anyString(), anyString(), anyString(), anyObject())).thenReturn(convertVulnerabilities(vulnerabilities));
         PolicyResult result = assetTypeGroupedVulnerabilitiesRule.execute(getRuleParams("critical"), getResourceAttributes());
         assertThat(result, is(notNullValue()));


### PR DESCRIPTION
## Description

When the CVE id is missing, use cveUrl instead of trying to form the URL to the CVE database. 

This allows the UI to display a URL - currently, no URL text is present, though a URL does exist which goes nowhere useful.

This can be seen with the 'Weak LAN Manager hashing permitted" vulnerability.

## Type of change

**Please delete options that are not relevant.**

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The associated test has been updated to include this scenario.

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] My commit message/PR follows the contribution guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of null or empty values for CVE ID and URL in vulnerability details.

- **Tests**
  - Updated test data to include new scenarios with empty CVE IDs and different titles and URLs for better coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->