### PR TITLE
feat:[UIUX-707] remove box icon from the empty and other error state message

### DIFF
--- a/webapp/src/app/shared/error-message/error-message.component.css
+++ b/webapp/src/app/shared/error-message/error-message.component.css
@@ -49,6 +49,7 @@
     padding: 5px;
     font: var(--text-body-2);
     color: var(--text-medium-emphasis);
+    font-size: 16px;
 }
 
 .error-state-wrapper img {

--- a/webapp/src/app/shared/error-message/error-message.component.html
+++ b/webapp/src/app/shared/error-message/error-message.component.html
@@ -13,7 +13,6 @@
  -->
 
 <div class="error-state-wrapper flex-col" *ngIf="errorMessages != undefined">
-    <img [src]="errorMessages.image" alt="" />
     <p class="bold-text">
         {{ errorMessages.title }}
     </p>


### PR DESCRIPTION
# Description
https://paladincloud.atlassian.net/browse/UIUX-707

Need to remove icons from error state, show only message.

Instead of error with icons :

<img width="575" alt="Screenshot 2024-06-06 at 1 00 24 PM" src="https://github.com/PaladinCloud/EE/assets/152586069/e8d60309-85e0-445e-990c-d86aa90d232c">
message 

**We need to remove icons and show only error message.**
Updated test cases in ticket UIUX-707
 
![screencapture-localhost-4202-pl-compliance-compliance-dashboard-2024-06-06-13_13_25](https://github.com/PaladinCloud/EE/assets/152586069/652f8ab9-07b5-4bb8-b673-452511a11247)

# Type of change
- [x] New feature (non-breaking change which adds functionality)

# Does this change include any breaking change? If Yes, please elaborate.
No

# How Has This Been Tested?

- [x] Unit testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The commit message/PR follows our guidelines

# **Other information**:
