### PR TITLE
feat:[UIUX-708] transform the policy name to camel case

### DIFF
--- a/webapp/src/app/pacman-features/modules/compliance/policy-knowledgebase-details/policy-knowledgebase-details.component.html
+++ b/webapp/src/app/pacman-features/modules/compliance/policy-knowledgebase-details/policy-knowledgebase-details.component.html
@@ -27,15 +27,13 @@
             [breadcrumbPresent]="breadcrumbPresent"
         ></app-breadcrumb>
     </div>
-    <div class="header flex">
+    <div class="header flex capitalize">
         <div class="header-text">
             <img
                 class="header-autofix-icon"
                 *ngIf="policyDetails?.autoFixAvailable === 'true'"
                 alt="Autofix state"
-                src="/assets/icons/{{
-                    policyDetails?.autoFixEnabled === 'true' ? '' : 'no-'
-                }}autofix.svg"
+                [src]="getImageSource(policyDetails)"
             />
             {{ policyDisplayName }}
         </div>

--- a/webapp/src/app/pacman-features/modules/compliance/policy-knowledgebase-details/policy-knowledgebase-details.component.ts
+++ b/webapp/src/app/pacman-features/modules/compliance/policy-knowledgebase-details/policy-knowledgebase-details.component.ts
@@ -354,6 +354,12 @@ export class PolicyKnowledgebaseDetailsComponent implements OnInit, OnDestroy {
         }
     }
 
+    getImageSource(policyDetails: any): string {
+        return policyDetails?.autoFixAvailable === 'true'
+            ? '/assets/icons/autofix.svg'
+            : '/assets/icons/no-autofix.svg';
+    }
+
     /*
      * unsubscribing component
      */


### PR DESCRIPTION
## Description
https://paladincloud.atlassian.net/browse/UIUX-708

Ensure that the policy name is always in camel case on both the admin policy details and user policy details screens.

### Problem

<img width="1656" alt="Screenshot 2024-06-07 at 5 32 06 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/a2eae497-a186-40ea-8ddb-44b2d29b71e1">

### Solution

<img width="1652" alt="Screenshot 2024-06-07 at 5 05 29 PM" src="https://github.com/PaladinCloud/EE/assets/152586069/8efc2f2f-2424-4f33-bd3b-7757613c80d3">

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Unit Testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved image handling in the policy knowledgebase details component to dynamically update image sources based on policy details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->