### PR TITLE
Get CVE list from 'vulnerabilities' field to allow more than…

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
@@ -117,11 +117,14 @@ public class AssetTypeGroupedVulnerabilitiesRule extends BasePolicy {
         List<VulnerabilityInfo> vulnerabilityList = new ArrayList<>();
         for (JsonObject vulnerability : vulnerabilityInfoList) {
             for (JsonElement cveDetails : vulnerability.get(severity).getAsJsonArray()) {
-                VulnerabilityInfo vul = new VulnerabilityInfo();
-                String cveId = cveDetails.getAsJsonObject().get("id").getAsString();
-                CveDetails cve = new CveDetails(cveId, PacmanUtils.NIST_VULN_DETAILS_URL + cveId);
                 List<CveDetails> cveList = new ArrayList<>();
-                cveList.add(cve);
+                for (JsonElement vulnerabilityItem : cveDetails.getAsJsonObject().get("vulnerabilities").getAsJsonArray()) {
+                    String cveId = vulnerabilityItem.getAsJsonObject().get("id").getAsString();
+                    String referenceUrl = vulnerabilityItem.getAsJsonObject().get("url").getAsString();
+                    CveDetails cve = new CveDetails(cveId, referenceUrl);
+                    cveList.add(cve);
+                }
+                VulnerabilityInfo vul = new VulnerabilityInfo();
                 vul.setCveList(cveList);
                 vul.setVulnerabilityUrl(cveDetails.getAsJsonObject().get("url").getAsString());
                 vul.setTitle(cveDetails.getAsJsonObject().get("title").getAsString());

--- a/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRuleTest.java
+++ b/jobs/pacman-awsrules/src/test/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRuleTest.java
@@ -32,7 +32,8 @@ public class AssetTypeGroupedVulnerabilitiesRuleTest {
     public void correctlyProcessCritical() throws Exception {
         mockStatic(PacmanUtils.class);
         when(PacmanUtils.doesAllHaveValue(anyString(), anyString())).thenReturn(true);
-        String vulnerabilities = "{ \"instanceId\": \"iid-1\", \"critical\": [ { \"id\": \"CVE-2024-29986\", \"severity\": \"severe\", \"title\": \"Microsoft Edge Chromium: CVE-2024-29986\", \"url\": \"https://example.com/microsoft-edge-cve-2024-29986/\" }, { \"id\": \"CVE-2024-29987\", \"severity\": \"severe\", \"title\": \"Microsoft Edge Chromium: CVE-2024-29987\", \"url\": \"https://example.com/microsoft-edge-cve-2024-29987/\" } ] }";
+//        String vulnerabilities = "{ \"instanceId\": \"iid-1\", \"critical\": [ { \"id\": \"CVE-2024-29986\", \"severity\": \"severe\", \"title\": \"Microsoft Edge Chromium: CVE-2024-29986\", \"url\": \"https://example.com/microsoft-edge-cve-2024-29986/\" }, { \"id\": \"CVE-2024-29987\", \"severity\": \"severe\", \"title\": \"Microsoft Edge Chromium: CVE-2024-29987\", \"url\": \"https://example.com/microsoft-edge-cve-2024-29987/\" } ] }";
+        String vulnerabilities = "{\"instanceId\":\"iid-1\",\"critical\":[{\"severity\":\"critical\",\"vulnerabilities\":[{\"id\":\"CVE-2020-36330\",\"url\":\"https://nvd.nist.gov/vuln/detail/CVE-2020-36330\"},{\"id\":\"CVE-2018-25014\",\"url\":\"https://nvd.nist.gov/vuln/detail/CVE-2018-25014\"},{\"id\":\"CVE-2018-25013\",\"url\":\"https://nvd.nist.gov/vuln/detail/CVE-2018-25013\"},{\"id\":\"CVE-2020-36331\",\"url\":\"https://nvd.nist.gov/vuln/detail/CVE-2020-36331\"}],\"title\":\"libwebp 0.3.0-10.amzn2\",\"url\":\"https://example.com\",\"referenceUrl\":\"https://nvd.nist.gov/vuln/detail/CVE-2020-36330\"},{\"severity\":\"critical\",\"vulnerabilities\":[{\"id\":\"CVE-2015-8394\",\"url\":\"https://nvd.nist.gov/vuln/detail/CVE-2015-8394\"},{\"id\":\"CVE-2015-8390\",\"url\":\"https://nvd.nist.gov/vuln/detail/CVE-2015-8390\"}],\"title\":\"pcre 8.32-17.amzn2.0.2\",\"url\":\"https://example.com\",\"referenceUrl\":\"https://nvd.nist.gov/vuln/detail/CVE-2015-8394\"}]}";
         when(PacmanUtils.matchAssetAgainstSourceVulnIndex(anyString(), anyString(), anyString(), anyObject())).thenReturn(convertVulnerabilities(vulnerabilities));
         PolicyResult result = assetTypeGroupedVulnerabilitiesRule.execute(getRuleParams("critical"), getResourceAttributes());
         assertThat(result, is(notNullValue()));
@@ -64,16 +65,24 @@ public class AssetTypeGroupedVulnerabilitiesRuleTest {
 
     private VulnerabilityInfo[] getExpectedVulnerabilityInfo() {
         VulnerabilityInfo[] v = new VulnerabilityInfo[2];
-        CveDetails[] cveList1 = {new CveDetails("CVE-2024-29986", "https://nvd.nist.gov/vuln/detail/CVE-2024-29986")};
+        CveDetails[] cveList1 = {
+            new CveDetails("CVE-2020-36330", "https://nvd.nist.gov/vuln/detail/CVE-2020-36330"),
+            new CveDetails("CVE-2018-25014", "https://nvd.nist.gov/vuln/detail/CVE-2018-25014"),
+            new CveDetails("CVE-2018-25013", "https://nvd.nist.gov/vuln/detail/CVE-2018-25013"),
+            new CveDetails("CVE-2020-36331", "https://nvd.nist.gov/vuln/detail/CVE-2020-36331")
+        };
         v[0] = new VulnerabilityInfo();
-        v[0].setTitle("Microsoft Edge Chromium: CVE-2024-29986");
-        v[0].setVulnerabilityUrl("https://example.com/microsoft-edge-cve-2024-29986/");
+        v[0].setTitle("libwebp 0.3.0-10.amzn2");
+        v[0].setVulnerabilityUrl("https://example.com");
         v[0].setCveList(Arrays.asList(cveList1));
 
-        CveDetails[] cveList2 = {new CveDetails("CVE-2024-29987", "https://nvd.nist.gov/vuln/detail/CVE-2024-29987")};
+        CveDetails[] cveList2 = {
+            new CveDetails("CVE-2015-8394", "https://nvd.nist.gov/vuln/detail/CVE-2015-8394"),
+            new CveDetails("CVE-2015-8390", "https://nvd.nist.gov/vuln/detail/CVE-2015-8390")
+        };
         v[1] = new VulnerabilityInfo();
-        v[1].setTitle("Microsoft Edge Chromium: CVE-2024-29987");
-        v[1].setVulnerabilityUrl("https://example.com/microsoft-edge-cve-2024-29987/");
+        v[1].setTitle("pcre 8.32-17.amzn2.0.2");
+        v[1].setVulnerabilityUrl("https://example.com/");
         v[1].setCveList(Arrays.asList(cveList2));
         return v;
     }


### PR DESCRIPTION
Get the CVE list from 'vulnerabilities' field to allow more than one per finding

Prior to this, the CVE list was always one item.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The associated tests have been updated and verified.

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of vulnerability details by updating the logic for retrieving and processing CVE information.

- **Tests**
  - Updated test cases to reflect the new structure and content of vulnerability data, ensuring accurate validation of critical vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->