### PR TITLE
fix:[PLG-564] Group CVEs by application

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/awsrules/ec2/AssetTypeGroupedVulnerabilitiesRule.java
@@ -123,21 +123,24 @@ public class AssetTypeGroupedVulnerabilitiesRule extends BasePolicy {
                     vul.setVulnerabilityUrl(cveDetails.getAsJsonObject().get("url").getAsString());
                     vul.setTitle(cveDetails.getAsJsonObject().get("title").getAsString());
                     /* If there is a list of cve IDs group it under this vulnerability info */
-                    if (cveDetails.getAsJsonObject().get("cves") != null && cveDetails.getAsJsonObject().get("cves").isJsonArray()) {
-                        JsonArray cveArray = cveDetails.getAsJsonObject().get("cves").getAsJsonArray();
-                        List<CveDetails> cveList = new ArrayList<>();
-                        for (JsonElement e : cveArray) {
-                            String cveId = e.getAsString();
+                    JsonElement cves = cveDetails.getAsJsonObject().get("cves");
+                    if (cves != null) {
+                        if (cves.isJsonArray()) {
+                            JsonArray cveArray = cves.getAsJsonArray();
+                            List<CveDetails> cveList = new ArrayList<>();
+                            for (JsonElement e : cveArray) {
+                                String cveId = e.getAsString();
+                                CveDetails cve = new CveDetails(cveId, PacmanUtils.NIST_VULN_DETAILS_URL + cveId);
+                                cveList.add(cve);
+                                vul.setCveList(cveList);
+                            }
+                        } else if (!StringUtils.isNullOrEmpty(cves.getAsString())) {
+                            String cveId = cves.getAsString();
                             CveDetails cve = new CveDetails(cveId, PacmanUtils.NIST_VULN_DETAILS_URL + cveId);
+                            List<CveDetails> cveList = new ArrayList<>(1);
                             cveList.add(cve);
                             vul.setCveList(cveList);
                         }
-                    } else {
-                        String cveId = cveDetails.getAsJsonObject().get("id").getAsString();
-                        CveDetails cve = new CveDetails(cveId, PacmanUtils.NIST_VULN_DETAILS_URL + cveId);
-                        List<CveDetails> cveList = new ArrayList<>(1);
-                        cveList.add(cve);
-                        vul.setCveList(cveList);
                     }
                     vulnerabilityList.add(vul);
                 }


### PR DESCRIPTION
## Description

- add all CVEs under same vuln info(for the application) if there is a list of CVEs
- else create a sincle cve under vuln info

### Problem

### Solution


## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Run mapper, shipper and then related policy
- [ ] verify that CVEs are grouped by application if the vulnerability model has list of CVEs grouped  by application(title)
- [ ] verify that vuln info has only one CVE when the vulnerability model has a single CVE per title

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced vulnerability processing to support grouping multiple CVE IDs under a single vulnerability.

- **Improvements**
  - Improved handling and display of vulnerability details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->