### PR TITLE
fix:[UIUX-735] audit log missing

### DIFF
--- a/webapp/src/app/pacman-features/modules/admin/account-management/account-management.component.ts
+++ b/webapp/src/app/pacman-features/modules/admin/account-management/account-management.component.ts
@@ -440,10 +440,12 @@ export class AccountManagementComponent implements OnInit, AfterViewInit, OnDest
                         cellObj = {
                             ...cellObj,
                             imgSrc: this.tableImageDataMap[
-                                row[TABLE_COLUMN_NAMES.SOURCE]?.toLowerCase()
+                                row[TABLE_COLUMN_NAMES.SOURCE]?.toLowerCase()?.replace(/\s+/g, '')
                             ]
                                 ? this.tableImageDataMap[
-                                      row[TABLE_COLUMN_NAMES.SOURCE].toLowerCase()
+                                      row[TABLE_COLUMN_NAMES.SOURCE]
+                                          ?.toLowerCase()
+                                          .replace(/\s+/g, '')
                                   ].image
                                 : 'noImg',
                             isLink: true,

--- a/webapp/src/app/pacman-features/modules/compliance/issue-details/issue-details.component.ts
+++ b/webapp/src/app/pacman-features/modules/compliance/issue-details/issue-details.component.ts
@@ -764,7 +764,7 @@ export class IssueDetailsComponent implements OnInit, OnDestroy {
                 this.VIOLATION_CONSTANTS.AUDIT_LOG.COLUMNS_KEYS;
             for (let i = 0; i < data.length; i++) {
                 data[i][date] = data[i]?.auditdate;
-                data[i][source] = data[i]?.createdBy?.split('@')[0];
+                data[i][source] = data[i]?.createdBy;
                 data[i][action] = data[i]?.action;
                 data[i][status] = data[i]?.status;
                 data[i][reason] = data[i]?.exemptionReason;
@@ -811,8 +811,9 @@ export class IssueDetailsComponent implements OnInit, OnDestroy {
                 }
                 return (
                     index &&
-                    this.outerArr[index - 1].Status.valueText.toLowerCase() !=
-                        obj.Status.valueText.toLowerCase()
+                    (this.outerArr[index - 1].Status.valueText.toLowerCase() !=
+                        obj.Status.valueText.toLowerCase() ||
+                        this.outerArr[index - 1].Action.valueText != obj.Action.valueText)
                 );
             });
 

--- a/webapp/src/app/pacman-features/secondary-components/pacman-policy-violations/pacman-policy-violations.component.ts
+++ b/webapp/src/app/pacman-features/secondary-components/pacman-policy-violations/pacman-policy-violations.component.ts
@@ -36,6 +36,7 @@ import {
     AssociatedPolicyStatusOrderMap,
     SeverityOrderMap,
 } from 'src/app/shared/constants/order-mapping';
+import { NO_POLICY_FOUND } from 'src/app/shared/constants/global';
 
 @Component({
     selector: 'app-pacman-policy-violations',
@@ -305,7 +306,8 @@ export class PacmanPolicyViolationsComponent implements OnInit, OnChanges, OnDes
                         this.dataComing = true;
 
                         if (response.response.length === 0 && this.firstTimeLoad) {
-                            this.errorMessage = 'noPolicyFound';
+                            this.errorMessage = NO_POLICY_FOUND;
+                            this.policyTableDataLoaded = true;
                         }
                         this.firstTimeLoad = false;
                         this.totalRows = response.total;

--- a/webapp/src/app/shared/constants/global.ts
+++ b/webapp/src/app/shared/constants/global.ts
@@ -4,6 +4,7 @@ export const API_RESPONSE_ERROR = 'apiResponseError';
 export const JS_ERROR = 'jsError';
 export const ERROR = 'error';
 export const NO_DATA_AVAILABLE = 'noDataAvailable';
+export const NO_POLICY_FOUND = 'noPolicyFound';
 
 // === Common Labels ===
 


### PR DESCRIPTION
## Description

https://paladincloud.atlassian.net/browse/UIUX-735

### Problem

- The "Violation Audit Logs" request exemption status is missing in the UI.
- In "Asset Details," the associated policy error and loader are being displayed.

<img width="786" alt="Screenshot 2024-07-05 at 1 27 20 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/6b1d108b-92dc-44c5-8693-8066ec861662">

### Solution

<img width="1109" alt="Screenshot 2024-07-05 at 12 57 37 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/eb5902db-f1f9-44f7-b683-9c7f91122ac7">

<img width="785" alt="Screenshot 2024-07-05 at 1 26 44 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/2b0978f9-4777-4618-891d-9245cf408226">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced image source handling in Account Management to remove whitespace, ensuring more accurate data retrieval.
  - Updated data access and comparison logic in Issue Details for improved accuracy in user and status/action handling.

- **New Features**
  - Introduced a new constant `NO_POLICY_FOUND` for better error handling in Pacman Policy Violations.

- **Bug Fixes**
  - Fixed an issue where error messages did not correctly reflect policy status in Pacman Policy Violations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->