### PR TITLE
fix:[UIUX-735] full-email-in-request

### DIFF
--- a/webapp/src/app/pacman-features/modules/compliance/issue-details/issue-details.component.ts
+++ b/webapp/src/app/pacman-features/modules/compliance/issue-details/issue-details.component.ts
@@ -887,7 +887,7 @@ export class IssueDetailsComponent implements OnInit, OnDestroy {
                 const email = this.dataStore.getUserDetailsValue().getEmail();
                 const payload = {
                     issueIds: [this.policyViolationId],
-                    revokedBy: email.split('@')[0],
+                    revokedBy: email,
                 };
                 const queryParams = {
                     ag: this.selectedAssetGroup,


### PR DESCRIPTION
## Description

When revoking an exemption, the API is only sending the name in the revokedBy key instead of the full email address.

### Problem

<img width="1656" alt="Screenshot 2024-07-05 at 4 13 40 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/fa3b5895-153f-4315-b69d-f40fe2b250fe">

### Solution

<img width="1655" alt="Screenshot 2024-07-05 at 4 09 31 PM" src="https://github.com/PaladinCloud/CE/assets/152586069/7b8e85c7-8ed0-4a1a-8505-bc00cc3c1063">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the display of the 'revoked by' field to show the full email address instead of just the username.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->