### PR TITLE
fix:[CORE-1833] Insert audit logs when dangling issues are closed

### DIFF
--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
@@ -693,4 +693,5 @@ public interface PacmanSdkConstants {
     String EXEMPTION_EXPIRED = "Exemption Expired";
     String SYSTEM = "System";
     String CREATED_BY = "createdBy";
+    String POLICY_DISABLED_MSG = "Policy has been disabled";
 }

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -52,6 +52,7 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static com.tmobile.pacman.common.PacmanSdkConstants.JOB_NAME;
+import static com.tmobile.pacman.common.PacmanSdkConstants.POLICY_DISABLED_MSG;
 import static com.tmobile.pacman.commons.PacmanSdkConstants.DATA_ALERT_ERROR_STRING;
 
 
@@ -111,7 +112,7 @@ public class PolicyExecutor {
         ExecutorService executor = Executors.newFixedThreadPool(POLICY_THREAD_POOL_SIZE);
         for (Map<String, String> policyParam : policyExecutor.policyWiseParamsList) {
             String executionId = UUID.randomUUID().toString(); // this is the unique
-            String status = fetchLatestPolicyStatus(policyParam);
+            String policyStatus = fetchLatestPolicyStatus(policyParam);
             policyParam.put("pluginName",policyExecutor.enricherSource);
             //String status = "ENABLED";
             executor.execute(() -> {
@@ -119,8 +120,8 @@ public class PolicyExecutor {
                     MDC.put("executionId", executionId);
                     MDC.put("jobName", policyParam.get(PacmanSdkConstants.POLICY_UUID_KEY));
                     if (policyExecutor.resources.isEmpty()
-                            || PacmanSdkConstants.POLICY_STATUS_DISABLED.equalsIgnoreCase(status)) {
-                        String reasonToClose = PacmanSdkConstants.POLICY_STATUS_DISABLED.equalsIgnoreCase(status) ? "Policy has been disabled" : PacmanSdkConstants.REASON_TO_CLOSE_VALUE;
+                            || PacmanSdkConstants.POLICY_STATUS_DISABLED.equalsIgnoreCase(policyStatus)) {
+                        String reasonToClose = policyExecutor.getReasonForIssueStatus(policyStatus);
                         AnnotationPublisher annotationPublisher = new AnnotationPublisher();
                         annotationPublisher.populateExistingIssuesForType(policyParam);
                         annotationPublisher.closeDanglingIssues(
@@ -142,6 +143,15 @@ public class PolicyExecutor {
         policyDoneSNS(args[0]);
         MDC.clear();
         ProgramExitUtils.exitSucessfully();
+    }
+
+    private String getReasonForIssueStatus(String policyStatus) {
+        if (PacmanSdkConstants.POLICY_STATUS_DISABLED.equalsIgnoreCase(policyStatus)) {
+            return POLICY_DISABLED_MSG;
+        } else if (this.resources.isEmpty()) {
+            return PacmanSdkConstants.REASON_TO_CLOSE_VALUE;
+        }
+        return null;
     }
 
     private void fetchPolicyWiseParams(String requestJson) {
@@ -559,7 +569,6 @@ public class PolicyExecutor {
                 annotation.put(PacmanSdkConstants.MODIFIED_DATE, evalDate);
                 annotation.put(PacmanSdkConstants.POLICY_SEVERITY,  policyParam.get(PacmanSdkConstants.POLICY_SEVERITY));
                 annotation.put(PacmanSdkConstants.POLICY_CATEGORY,  policyParam.get(PacmanSdkConstants.POLICY_CATEGORY));
-                // annotationPublisher.publishAnnotationToEs(annotation);
                 annotationPublisher.submitToPublish(annotation);
                 issueFoundCounter++;
                 logger.info("submitted annotation to publisher");
@@ -568,24 +577,7 @@ public class PolicyExecutor {
         }
         metrics.put("totalExemptionAppliedForThisRun", exemptionCounter);
         annotationPublisher.setRuleParam(ImmutableMap.<String, String>builder().putAll(policyParam).build());
-        // annotation will contain the last annotation processed above
-
-        //  if (!isResourceFilterExists) {
-        annotationPublisher.setExistingResources(resources); // if resources
-        // are not
-        // filtered
-        // then no need
-        // to make
-        // another
-        // call.
-       /* }
-        // this will be used for closing issues if resources are filtered
-        // already this will prevent actual issues to close
-        else {
-            annotationPublisher
-                    .setExistingResources(ESUtils.getResourcesFromEs(CommonUtils.getIndexNameFromRuleParam(policyParam),
-                            policyParam.get(PacmanSdkConstants.TARGET_TYPE), null, null));
-        }*/
+        annotationPublisher.setExistingResources(resources);
         annotationPublisher.publish();
         metrics.put("total-issues-found", issueFoundCounter);
         List<Annotation> closedIssues = annotationPublisher.processClosureEx();
@@ -593,6 +585,7 @@ public class PolicyExecutor {
         NotificationUtils.triggerNotificationsForViolations(bulkUploadAnnotations, annotationPublisher.getExistingIssuesMapWithAnnotationIdAsKey(), true);
         NotificationUtils.triggerNotificationsForViolations(annotationPublisher.getClouserBucket(), annotationPublisher.getExistingIssuesMapWithAnnotationIdAsKey(), false);
 
+        // annotation will contain the last annotation processed above
         Integer danglisngIssues = annotationPublisher.closeDanglingIssues(annotation, PacmanSdkConstants.REASON_TO_CLOSE_VALUE);
         metrics.put("dangling-issues-closed", danglisngIssues);
         metrics.put("total-issues-closed", closedIssues.size() + danglisngIssues);

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -120,12 +120,13 @@ public class PolicyExecutor {
                     MDC.put("jobName", policyParam.get(PacmanSdkConstants.POLICY_UUID_KEY));
                     if (policyExecutor.resources.isEmpty()
                             || PacmanSdkConstants.POLICY_STATUS_DISABLED.equalsIgnoreCase(status)) {
+                        String reasonToClose = PacmanSdkConstants.POLICY_STATUS_DISABLED.equalsIgnoreCase(status) ? "Policy has been disabled" : PacmanSdkConstants.REASON_TO_CLOSE_VALUE;
                         AnnotationPublisher annotationPublisher = new AnnotationPublisher();
                         annotationPublisher.populateExistingIssuesForType(policyParam);
                         annotationPublisher.closeDanglingIssues(
                                 policyParam.get(PacmanSdkConstants.DATA_SOURCE_KEY) + "_"
                                         + policyParam.get(PacmanSdkConstants.TARGET_TYPE),
-                                policyParam.get(PacmanSdkConstants.TARGET_TYPE));
+                                reasonToClose);
                     } else {
                         policyExecutor.run(policyParam, executionId);
                     }

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -593,7 +593,7 @@ public class PolicyExecutor {
         NotificationUtils.triggerNotificationsForViolations(bulkUploadAnnotations, annotationPublisher.getExistingIssuesMapWithAnnotationIdAsKey(), true);
         NotificationUtils.triggerNotificationsForViolations(annotationPublisher.getClouserBucket(), annotationPublisher.getExistingIssuesMapWithAnnotationIdAsKey(), false);
 
-        Integer danglisngIssues = annotationPublisher.closeDanglingIssues(annotation);
+        Integer danglisngIssues = annotationPublisher.closeDanglingIssues(annotation, PacmanSdkConstants.REASON_TO_CLOSE_VALUE);
         metrics.put("dangling-issues-closed", danglisngIssues);
         metrics.put("total-issues-closed", closedIssues.size() + danglisngIssues);
         List<Annotation> allIssues = new ArrayList<>(bulkUploadAnnotations.size() + closedIssues.size());

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/publisher/impl/AnnotationPublisher.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/publisher/impl/AnnotationPublisher.java
@@ -408,7 +408,7 @@ public class AnnotationPublisher {
      * @return the int
      * @throws Exception the exception
      */
-    public int closeDanglingIssues(String _index, String _type) throws Exception {
+    public int closeDanglingIssues(String _index, String reason) throws Exception {
         String esUrl = ESUtils.getEsUrl();
         StringBuffer bulkRequestBody = new StringBuffer();
         String bulkIndexRequestTemplate = BULK_UPDATE_REQUEST_TEMPLATE;
@@ -437,7 +437,8 @@ public class AnnotationPublisher {
                     .getCurrentDateStringWithFormat(PacmanSdkConstants.PAC_TIME_ZONE, PacmanSdkConstants.DATE_FORMAT));
             issue.put(PacmanSdkConstants.MODIFIED_DATE, CommonUtils
                     .getCurrentDateStringWithFormat(PacmanSdkConstants.PAC_TIME_ZONE, PacmanSdkConstants.DATE_FORMAT));
-            issueToClose.put(PacmanSdkConstants.REASON_TO_CLOSE_KEY, PacmanSdkConstants.REASON_TO_CLOSE_VALUE);
+            issue.put(PacmanSdkConstants.REASON_TO_CLOSE_KEY, reason);
+            issueToClose.put(PacmanSdkConstants.REASON_TO_CLOSE_KEY, reason);
             issueToClose.put(PacmanSdkConstants.ISSUE_STATUS_KEY, PacmanSdkConstants.STATUS_CLOSE);
             issueToClose.put(PacmanSdkConstants.ISSUE_CLOSED_DATE, CommonUtils
                     .getCurrentDateStringWithFormat(PacmanSdkConstants.PAC_TIME_ZONE, PacmanSdkConstants.DATE_FORMAT));

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/publisher/impl/AnnotationPublisher.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/publisher/impl/AnnotationPublisher.java
@@ -15,23 +15,22 @@
  ******************************************************************************/
 package com.tmobile.pacman.publisher.impl;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.tmobile.pacman.common.PacmanSdkConstants;
+import com.tmobile.pacman.commons.policy.Annotation;
+import com.tmobile.pacman.util.AuditUtils;
+import com.tmobile.pacman.util.CommonUtils;
+import com.tmobile.pacman.util.ESUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.google.gson.*;
-import com.tmobile.pacman.commons.dao.RDSDBManager;
-import com.tmobile.pacman.executor.PolicyExecutor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableMap;
-import com.tmobile.pacman.common.PacmanSdkConstants;
-import com.tmobile.pacman.commons.policy.Annotation;
-import com.tmobile.pacman.util.CommonUtils;
-import com.tmobile.pacman.util.ESUtils;
 
 import static com.tmobile.pacman.common.PacmanSdkConstants.JOB_NAME;
 import static com.tmobile.pacman.commons.PacmanSdkConstants.*;
@@ -458,6 +457,7 @@ public class AnnotationPublisher {
         if (bulkRequestBody.length() > 0) {
             CommonUtils.doHttpPost(bulkPostUrl, bulkRequestBody.toString(),new HashMap<>());
         }
+        AuditUtils.postAuditTrail(new ArrayList<>(getExistingIssuesMapWithAnnotationIdAsKey().values()), null);
         return totalClosed;
     }
 

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/publisher/impl/AnnotationPublisher.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/publisher/impl/AnnotationPublisher.java
@@ -393,11 +393,9 @@ public class AnnotationPublisher {
      * @return the int
      * @throws Exception the exception
      */
-    public int closeDanglingIssues(Annotation sampleAnnotation) throws Exception {
+    public int closeDanglingIssues(Annotation sampleAnnotation, String reason) throws Exception {
         String indexName = ESUtils.buildIndexNameFromAnnotation(sampleAnnotation);
-        String typeIssue = ESUtils.getIssueTypeFromAnnotation(sampleAnnotation);
-        return closeDanglingIssues(indexName, typeIssue);
-
+        return closeDanglingIssues(indexName, reason);
     }
 
     /**

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/CommonUtils.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/CommonUtils.java
@@ -514,7 +514,7 @@ public class CommonUtils {
      * @param annotation the annotation
      * @return the unique annotation id
      */
-    public static String getUniqueAnnotationId(Annotation annotation) {
+    public static String getUniqueAnnotationId(Map<String, String> annotation) {
         return getUniqueAnnotationId(annotation.get(PacmanSdkConstants.DOC_ID),
                 annotation.get(PacmanSdkConstants.POLICY_ID));
     }


### PR DESCRIPTION
## Description

- issue: audit log entry is missed when dangling issues are closed by policy executor
- fix: made  AuditUtils.postAuditTrail generic and used the same common method to insert audit log when dangling issues are closed

### Problem
audit log entry is missed when dangling issues are closed by policy executor

### Solution
made  AuditUtils.postAuditTrail generic and used the same common method to insert audit log when dangling issues are closed

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [X] Replicate the issue first by disabling the policy 'Check for Publicly Accessible Cloud KMS Keys' and verify there is no audit log with status = closed
- [X] enable the same policy again, apply fix and disable the policy
- [X] verify there is an audit log with status = closed

![image](https://github.com/PaladinCloud/CE/assets/149176078/2312fcbe-0895-4f17-a8ae-984c7586c61e)
![image](https://github.com/PaladinCloud/CE/assets/149176078/78c335b8-20a8-47ef-acad-436e632ad3f3)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new constant `POLICY_DISABLED_MSG` to communicate disabled policy status.

- **Improvements**
  - Enhanced auditing by updating methods in `AuditUtils` to accept map structures instead of specific objects.

- **Bug Fixes**
  - Improved closing of dangling issues in `PolicyExecutor` with a new condition based on policy status.

- **Refactor**
  - Updated method signatures in `AuditUtils` and `CommonUtils` for accepting map structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->