### PR TITLE
fix:[CUS-297] Added _docid to violation global search attributes

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -1446,7 +1446,7 @@ INSERT IGNORE INTO OmniSearch_Config (SEARCH_CATEGORY,RESOURCE_TYPE,REFINE_BY_FI
 INSERT IGNORE INTO OmniSearch_Config (SEARCH_CATEGORY,RESOURCE_TYPE,REFINE_BY_FIELDS,RETURN_FIELDS) VALUES ('Assets','vpngateway','state,type','region,state,type');
 INSERT IGNORE INTO OmniSearch_Config (SEARCH_CATEGORY,RESOURCE_TYPE,REFINE_BY_FIELDS,RETURN_FIELDS) VALUES ('Assets','elasticache','engine,nodetype,engineversion','region,engine');
 INSERT IGNORE INTO OmniSearch_Config (SEARCH_CATEGORY,RESOURCE_TYPE,REFINE_BY_FIELDS,RETURN_FIELDS) VALUES ('Assets','wafdomain','','');
-INSERT IGNORE INTO OmniSearch_Config (SEARCH_CATEGORY,RESOURCE_TYPE,REFINE_BY_FIELDS,RETURN_FIELDS) VALUES ('Policy Violations','All','severity,policyId','_id,issueid,resourceid,severity,_entitytype,_resourceid');
+INSERT IGNORE INTO OmniSearch_Config (SEARCH_CATEGORY,RESOURCE_TYPE,REFINE_BY_FIELDS,RETURN_FIELDS) VALUES ('Policy Violations','All','severity,policyId','_id,issueid,resourceid,severity,_entitytype,_docid,_resourceid');
 INSERT IGNORE INTO OmniSearch_Config (SEARCH_CATEGORY,RESOURCE_TYPE,REFINE_BY_FIELDS,RETURN_FIELDS) VALUES ('Vulnerabilities','All','severity,category,vulntype','qid,vulntype,category,_entitytype,_resourceid');
 
 


### PR DESCRIPTION
## Description

### Problem
docid is not added to the global search for violations.

### Solution
Added the docid attribute for violation global search.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

It was tested in saasdev.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `Policy Violations` search to include document IDs (`_docid`) in search results for more detailed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->