### PR TITLE
fix:[CORE-2045]System status showing "Exempted" instead of Exempt

### DIFF
--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
@@ -259,8 +259,13 @@ public interface PacmanSdkConstants {
 
     /** The status exempted. */
     String STATUS_EXEMPTED = "exempted";
-
-    /** The status success. */
+    /**
+     * Audit log status
+     */
+    String STATUS_EXEMPT = "exempt";
+    /**
+     * The status success.
+     */
     String STATUS_SUCCESS = "success";
 
     /** The status success. */

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/AuditUtils.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/AuditUtils.java
@@ -126,6 +126,10 @@ public class AuditUtils {
                 PacmanSdkConstants.DATE_FORMAT);
         Map<String, Object> auditTrail = new LinkedHashMap<>();
         auditTrail.put(PacmanSdkConstants.DOC_TYPE,_type);
+        //We need to show status as "EXEMPT" in Audit log instead of "Exempted" for UI Consistency
+        if (status.equalsIgnoreCase(PacmanSdkConstants.STATUS_EXEMPTED)) {
+            status = PacmanSdkConstants.STATUS_EXEMPT;
+        }
         // add relations to annotation
         Map<String, Object> relMap = new HashMap<>();
         relMap.put("name",_type);

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/AuditUtils.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/AuditUtils.java
@@ -126,7 +126,7 @@ public class AuditUtils {
                 PacmanSdkConstants.DATE_FORMAT);
         Map<String, Object> auditTrail = new LinkedHashMap<>();
         auditTrail.put(PacmanSdkConstants.DOC_TYPE,_type);
-        //We need to show status as "EXEMPT" in Audit log instead of "Exempted" for UI Consistency
+        //For System entries,We need to show status as "EXEMPT" in Audit log instead of "Exempted" for UI Consistency
         if (status.equalsIgnoreCase(PacmanSdkConstants.STATUS_EXEMPTED)) {
             status = PacmanSdkConstants.STATUS_EXEMPT;
         }


### PR DESCRIPTION
## Description

When Policy engine runs and see the violation status as "exempt" due to User's action (when Admin approves exemption request or Admin add them), System populates Audit log entry showing "Exempted". But for UI consistency this has to be displayed as "Exempt" because all user's action entries are showing as "Exempt" which is standard defined status as per new Audit log design.
### Problem
The root cause of the problem is audit log is simply using the issue status coming from ES which always stored "exempted" when violation is exempted.
### Solution
For Audit log , we need to add condition for modifying the status to "EXEMPT"

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration
**Test screen shot post fix**
![image](https://github.com/PaladinCloud/CE/assets/138756904/1f457852-6a69-4078-9372-18eb85f90de4)
![image](https://github.com/PaladinCloud/CE/assets/138756904/92481e4f-f245-4acd-a476-f509a4c36688)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My commit message/PR follows the contribution guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated audit log status display from "Exempted" to "EXEMPT" for consistent terminology across the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->