### PR TITLE
fix:[CORE-1833] Insert audit logs when dangling issues are closed

### DIFF
--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
@@ -693,4 +693,5 @@ public interface PacmanSdkConstants {
     String EXEMPTION_EXPIRED = "Exemption Expired";
     String SYSTEM = "System";
     String CREATED_BY = "createdBy";
+    String POLICY_DISABLED_MSG = "Policy has been disabled";
 }

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/CommonUtils.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/CommonUtils.java
@@ -514,7 +514,7 @@ public class CommonUtils {
      * @param annotation the annotation
      * @return the unique annotation id
      */
-    public static String getUniqueAnnotationId(Annotation annotation) {
+    public static String getUniqueAnnotationId(Map<String, String> annotation) {
         return getUniqueAnnotationId(annotation.get(PacmanSdkConstants.DOC_ID),
                 annotation.get(PacmanSdkConstants.POLICY_ID));
     }


### PR DESCRIPTION
## Description

- issue: audit log entry is missed when dangling issues are closed by policy executor
- fix: made  AuditUtils.postAuditTrail generic and used the same common method to insert audit log when dangling issues are closed

### Problem
audit log entry is missed when dangling issues are closed by policy executor

### Solution
made  AuditUtils.postAuditTrail generic and used the same common method to insert audit log when dangling issues are closed

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [X] Replicate the issue first by disabling the policy 'Check for Publicly Accessible Cloud KMS Keys' and verify there is no audit log with status = closed
- [X] enable the same policy again, apply fix and disable the policy
- [X] verify there is an audit log with status = closed

![image](https://github.com/PaladinCloud/CE/assets/149176078/2312fcbe-0895-4f17-a8ae-984c7586c61e)
![image](https://github.com/PaladinCloud/CE/assets/149176078/78c335b8-20a8-47ef-acad-436e632ad3f3)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new constant `POLICY_DISABLED_MSG` to communicate disabled policy status.

- **Improvements**
  - Enhanced auditing by updating methods in `AuditUtils` to accept map structures instead of specific objects.

- **Bug Fixes**
  - Improved closing of dangling issues in `PolicyExecutor` with a new condition based on policy status.

- **Refactor**
  - Updated method signatures in `AuditUtils` and `CommonUtils` for accepting map structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->