### PR TITLE
fix:[PLG-640] Handle port * for azure nsg policy

### DIFF
--- a/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/NSGRule/PublicAccessforConfiguredPort.java
+++ b/jobs/pacman-awsrules/src/main/java/com/tmobile/cloud/azurerules/NSGRule/PublicAccessforConfiguredPort.java
@@ -166,6 +166,9 @@ public class PublicAccessforConfiguredPort extends BasePolicy {
     private boolean checkDestinationPort(JsonArray destinationPorts, String[] validatePorts) {
         logger.info("checkDestinationPort");
 
+        if (ArrayUtils.contains(validatePorts, PacmanRuleConstants.PORT_ANY)) {
+            return true;
+        }
         for (int i = 0; i < destinationPorts.size(); i++) {
             /* ports can also be configured in ranges e.g. 3000-3500. For range, check if the port to be validated falls between this range */
             if (destinationPorts.get(i).getAsString().contains("-")) {
@@ -173,8 +176,7 @@ public class PublicAccessforConfiguredPort extends BasePolicy {
                 int fromPort = Integer.valueOf(portArr[0]);
                 int toPort = Integer.valueOf(portArr[1]);
                 return Arrays.stream(validatePorts).map(Integer::valueOf).anyMatch(port -> fromPort <= port && port <= toPort);
-            } else if (ArrayUtils.contains(validatePorts, destinationPorts.get(i).getAsString())
-                    || ArrayUtils.contains(validatePorts, PacmanRuleConstants.PORT_ANY)) {
+            } else if (ArrayUtils.contains(validatePorts, destinationPorts.get(i).getAsString())) {
                 return true;
             }
         }


### PR DESCRIPTION
## Description

- Handle port * for azure nsg policy

### Problem
all ports were considered as a number when there is a case it can be * for the rule "Deny Public Access to User Datagram Protocol (UDP)"

### Solution
Handle * and parse only port with numbers

## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Run the policy rule for azure NSG without the fix and verify the issue is replicated
- [ ] Run the policy rule for azure NSG with the fix and verify the issue is not seen again in logs

![image](https://github.com/user-attachments/assets/920a6d23-c234-4da8-bf7c-9e686176bfca)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced the efficiency and readability of the port validation logic in the application, allowing for quicker evaluations when any port is deemed valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->