### PR TITLE
fix:[NEXT-309] fix shipper for elasticache asset type

### DIFF
--- a/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/file/FileManager.java
+++ b/jobs/pacman-cloud-discovery/src/main/java/com/tmobile/cso/pacman/inventory/file/FileManager.java
@@ -1715,13 +1715,13 @@ public class FileManager {
                 + "`securitygroups`parametergroup`vpc`subnets";
         FileGenerator.generateJson(fileInfoMap, fieldNames, "aws-elasticache.data", keys);
 
-        fieldNames = "clusterName`tags.key`tags.value";
-        keys = "discoverydate`accountid`accountname`region`clustername`key`value";
+        fieldNames = "arn`clusterName`tags.key`tags.value";
+        keys = "discoverydate`accountid`accountname`region`arn`clustername`key`value";
         FileGenerator.generateJson(fileInfoMap, fieldNames, "aws-elasticache-tags.data", keys);
 
-        fieldNames = "clusterName`nodes.nodeName`nodes.node.cacheNodeStatus`nodes.node.cacheNodeCreateTime`nodes.node.parameterGroupStatus"
+        fieldNames = "arn`clusterName`nodes.nodeName`nodes.node.cacheNodeStatus`nodes.node.cacheNodeCreateTime`nodes.node.parameterGroupStatus"
                 + "`nodes.node.endpoint.address`nodes.node.endpoint.port`nodes.node.customerAvailabilityZone`nodes.tags";
-        keys = "discoverydate`accountid`accountname`region`clustername`nodeName`status`createdOn`parameterGroupStatus`endPointAddress`endPointPort`availabilityZone`tagStr";
+        keys = "discoverydate`accountid`accountname`region`arn`clustername`nodeName`status`createdOn`parameterGroupStatus`endPointAddress`endPointPort`availabilityZone`tagStr";
         FileGenerator.generateJson(fileInfoMap, fieldNames, "aws-elasticache-nodes.data", keys);
 
     }


### PR DESCRIPTION
fix:[NEXT-309][CUS-312] fix shipper for elasticache asset type
Shipper fix for too_many_nested_clauses exception 


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


[NEXT-309]: https://paladincloud.atlassian.net/browse/NEXT-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON file generation for AWS Elasticache resources, now including ARN for better resource identification.
	- Introduced a new method for generating Kinesis data stream files, also incorporating ARN in the output.

- **Bug Fixes**
	- Streamlined error handling in the error management system, improving processing efficiency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->