### PR TITLE
fix:[NEXT-349] Authorizer status code must return 401 for expired token

### DIFF
--- a/subsystem/auth/services/svc-api-authorizer/main.go
+++ b/subsystem/auth/services/svc-api-authorizer/main.go
@@ -40,6 +40,7 @@ func HandleRequest(ctx context.Context, request events.APIGatewayV2HTTPRequest) 
 	if err != nil {
 		if err.Error() == service.UnauthorizedMessage {
 			log.Info("denying access")
+			return events.APIGatewayV2CustomAuthorizerSimpleResponse{}, err
 		} else {
 			log.Error("error authorizing user", err)
 		}


### PR DESCRIPTION
## Description
- currently, Authorizer returns 403 when status code is expired
- returning error from lambda handler returns 401 for expired token

Please include a summary of the changes and the related issues. Please also include relevant motivation and context. List
any dependencies that are required for this change.

### Problem

### Solution


## Fixes # (issue if any)

## Type of change

**Please delete options that are not relevant.**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (no code changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My commit message/PR follows the contribution guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## **Other Information**:

## List any documentation updates that are needed for the Wiki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error messaging for unauthorized access and token expiration scenarios.
	- Introduced a specific message for expired tokens.

- **Bug Fixes**
	- Improved error handling logic to provide clearer feedback during authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->