### PR TITLE
feat:[NEXT-287] Direct aws, azure & gcp to the asset state service

### DIFF
--- a/commons/pac-batch-commons/src/main/java/com/tmobile/pacman/commons/aws/sqs/SQSManager.java
+++ b/commons/pac-batch-commons/src/main/java/com/tmobile/pacman/commons/aws/sqs/SQSManager.java
@@ -23,6 +23,7 @@ import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tmobile.pacman.commons.aws.CredentialProvider;
+import com.tmobile.pacman.commons.dto.AssetStateStartEvent;
 import com.tmobile.pacman.commons.dto.JobDoneMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +40,10 @@ public class SQSManager {
 
     public static SQSManager getInstance() {
         return InstanceHolder.instance;
+    }
+
+    public String sendMessage(AssetStateStartEvent message, String url) {
+        return sendMessage(message.toCommandLine(), url);
     }
 
     public String sendSQSMessage(JobDoneMessage jobDoneMessage, String url) {

--- a/commons/pac-batch-commons/src/main/java/com/tmobile/pacman/commons/dto/AssetStateStartEvent.java
+++ b/commons/pac-batch-commons/src/main/java/com/tmobile/pacman/commons/dto/AssetStateStartEvent.java
@@ -1,0 +1,20 @@
+package com.tmobile.pacman.commons.dto;
+
+public class AssetStateStartEvent {
+    private final String tenantId;
+    private final String dataSource;
+    private final String[] assetTypes;
+    private final boolean isFromPolicyEngine;
+
+    public AssetStateStartEvent(String tenantId, String dataSource, String[] assetTypes, boolean isFromPolicyEngine) {
+        this.tenantId = tenantId;
+        this.dataSource = dataSource;
+        this.assetTypes = assetTypes;
+        this.isFromPolicyEngine = isFromPolicyEngine;
+    }
+
+    public String toCommandLine() {
+        return String.format("--tenant_id=%s --data_source=%s --asset_types=%s --is_from_policy_engine=%s",
+            tenantId, dataSource, String.join(",", assetTypes), isFromPolicyEngine);
+    }
+}

--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/Main.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/Main.java
@@ -15,18 +15,19 @@
  ******************************************************************************/
 package com.tmobile.cso.pacman.datashipper;
 
+import com.tmobile.cso.pacman.datashipper.config.ConfigManager;
 import com.tmobile.cso.pacman.datashipper.dto.DatasourceData;
 import com.tmobile.cso.pacman.datashipper.entity.*;
 import com.tmobile.cso.pacman.datashipper.es.ESManager;
 import com.tmobile.cso.pacman.datashipper.util.Constants;
 import com.tmobile.cso.pacman.datashipper.util.ErrorManageUtil;
 import com.tmobile.pacman.commons.aws.sqs.SQSManager;
+import com.tmobile.pacman.commons.dto.AssetStateStartEvent;
 import com.tmobile.pacman.commons.dto.JobDoneMessage;
 import com.tmobile.pacman.commons.jobs.PacmanJob;
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
 
 @PacmanJob(methodToexecute = "shipData", jobName = "data-shipper", desc = "Job to load data from s3 to OP", priority = 5)
 public class Main implements Constants {
@@ -107,10 +108,28 @@ public class Main implements Constants {
             errorList.add(errorMap);
             LOGGER.error("Error while updating stats", e);
         }
+
+        // Route all assets through the asset state service, which will route to the policy engine
+        // once it's done processing.
         SQSManager sqsManager = SQSManager.getInstance();
-        JobDoneMessage jobDoneMessage = new JobDoneMessage(ds + "-Shipper-Job", tenantId, ds, null);
-        String sqsMessageID = sqsManager.sendSQSMessage(jobDoneMessage, System.getenv("SHIPPER_SQS_QUEUE_URL"));
-        LOGGER.debug("Shipper done SQS message ID: {}", sqsMessageID);
+        boolean isAsset = ds.equalsIgnoreCase("azure")
+            || ds.equalsIgnoreCase("aws")
+            || ds.equalsIgnoreCase("gcp");
+        if (isAsset) {
+            List<String> assetTypes = new ArrayList<>(ConfigManager.getTypesWithDisplayName(ds).keySet());
+            Collections.sort(assetTypes);
+            AssetStateStartEvent assetStateStartEvent =
+              new AssetStateStartEvent(tenantId, ds, assetTypes.toArray(new String[0]), false);
+            String sqsMessageID =
+                sqsManager.sendMessage(assetStateStartEvent, System.getenv("ASSET_STATE_QUEUE_URL"));
+            LOGGER.debug("AssetState Start SQS message ID: {}", sqsMessageID);
+        } else {
+            JobDoneMessage jobDoneMessage = new JobDoneMessage(ds + "-Shipper-Job", tenantId, ds, null);
+            String sqsMessageID =
+                sqsManager.sendSQSMessage(jobDoneMessage, System.getenv("SHIPPER_SQS_QUEUE_URL"));
+            LOGGER.debug("Shipper done SQS message ID: {}", sqsMessageID);
+        }
+
         Map<String, Object> status = ErrorManageUtil.formErrorCode(jobName, errorList);
         LOGGER.info("Job Return Status {} ", status);
         return status;


### PR DESCRIPTION
## Description

Send the asset state service start event when finished processing assets. Currently, these are aws, azure & gcp.

NOTE: The asset state service in the ce-extensions repository must be deployed and validated prior to deploying this change.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually validated sending event.
## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My commit message/PR follows the contribution guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
