### PR TITLE
feature:[NEXT-460] Add tenantId to policy event

### DIFF
--- a/commons/pac-batch-commons/src/main/java/com/tmobile/pacman/commons/dto/NotificationBaseRequest.java
+++ b/commons/pac-batch-commons/src/main/java/com/tmobile/pacman/commons/dto/NotificationBaseRequest.java
@@ -32,6 +32,7 @@ public class NotificationBaseRequest {
     private String eventDescription;
     private String subject;
     private Object payload;
+    private String tenantId;
 
     public NotificationBaseRequest(){
 
@@ -112,5 +113,13 @@ public class NotificationBaseRequest {
 
     public void setEventCategory(Constants.NotificationTypes eventCategory) {
         this.eventCategory = eventCategory;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 }

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -158,6 +158,15 @@ public class PolicyExecutor {
                 policyStatusChanged = true;
             }
             policyParam.put("pluginName",policyExecutor.enricherSource);
+
+            // If it's not passed in as a parameter, grab it from the environment
+            if (!policyParam.containsKey("tenantId")) {
+                String tenantId = System.getenv("TENANT_ID");
+                if (tenantId == null) {
+                    tenantId = "";
+                }
+                policyParam.put("tenantId", tenantId);
+            }
             //String status = "ENABLED";
             executor.execute(() -> {
                 try {
@@ -669,8 +678,9 @@ public class PolicyExecutor {
         metrics.put("total-issues-found", issueFoundCounter);
         List<Annotation> closedIssues = annotationPublisher.processClosureEx();
         List<Annotation> bulkUploadAnnotations = annotationPublisher.getBulkUploadBucket();
-        NotificationUtils.triggerNotificationsForViolations(bulkUploadAnnotations, annotationPublisher.getExistingIssuesMapWithAnnotationIdAsKey(), true);
-        NotificationUtils.triggerNotificationsForViolations(annotationPublisher.getClouserBucket(), annotationPublisher.getExistingIssuesMapWithAnnotationIdAsKey(), false);
+        String tenantId = policyParam.getOrDefault("tenantId", "");
+        NotificationUtils.triggerNotificationsForViolations(tenantId, bulkUploadAnnotations, annotationPublisher.getExistingIssuesMapWithAnnotationIdAsKey(), true);
+        NotificationUtils.triggerNotificationsForViolations(tenantId, annotationPublisher.getClouserBucket(), annotationPublisher.getExistingIssuesMapWithAnnotationIdAsKey(), false);
 
         // annotation will contain the last annotation processed above
         Integer danglisngIssues = annotationPublisher.closeDanglingIssues(annotation, PacmanSdkConstants.REASON_TO_CLOSE_VALUE);

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/NotificationUtils.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/NotificationUtils.java
@@ -33,7 +33,7 @@ public class NotificationUtils {
     private static PaladinAccessToken accessToken;
     private static final Logger LOGGER = LoggerFactory.getLogger(NotificationUtils.class);
 
-    public static void triggerNotificationsForViolations(List<Annotation> annotations, Map<String, Map<String, String>> existingIssuesMap, boolean isOpen) {
+    public static void triggerNotificationsForViolations(String tenantId, List<Annotation> annotations, Map<String, Map<String, String>> existingIssuesMap, boolean isOpen) {
         try {
             Gson gson = new Gson();
             String hostName = CommonUtils.getPropValue(HOSTNAME);
@@ -47,10 +47,10 @@ public class NotificationUtils {
                 Map<String, String> issueAttributes = existingIssuesMap.get(annotationId);
 
                 if (isOpen && null == issueAttributes && PacmanSdkConstants.STATUS_OPEN.equals(annotation.get(PacmanSdkConstants.ISSUE_STATUS_KEY))) {
-                    notificationDetailsList.add(getNotificationBaseRequest(annotation, hostName, true, CREATE_VIOLATION_EVENT_NAME));
+                    notificationDetailsList.add(getNotificationBaseRequest(tenantId, annotation, hostName, true, CREATE_VIOLATION_EVENT_NAME));
                 } else if (!isOpen && existingIssuesMap.containsKey(annotationId)
                         && PacmanSdkConstants.STATUS_CLOSE.equals(annotation.get(PacmanSdkConstants.ISSUE_STATUS_KEY))) {
-                        notificationDetailsList.add(getNotificationBaseRequest(annotation, hostName, false, CLOSE_VIOLATION_EVENT_NAME));
+                        notificationDetailsList.add(getNotificationBaseRequest(tenantId, annotation, hostName, false, CLOSE_VIOLATION_EVENT_NAME));
                 }
             }
             if (!notificationDetailsList.isEmpty()) {
@@ -66,13 +66,14 @@ public class NotificationUtils {
         }
     }
 
-    private static NotificationBaseRequest getNotificationBaseRequest(Annotation annotation, String hostName, boolean isOpen, String violationEventName) {
+    private static NotificationBaseRequest getNotificationBaseRequest(String tenantId, Annotation annotation, String hostName, boolean isOpen, String violationEventName) {
         NotificationBaseRequest notificationBaseRequest = new NotificationBaseRequest();
         notificationBaseRequest.setEventCategory(Constants.NotificationTypes.VIOLATION);
         notificationBaseRequest.setSubject(isOpen?OPEN_VIOLATIONS_SUBJECT:CLOSE_VIOLATIONS_SUBJECT);
         notificationBaseRequest.setEventCategoryName(Constants.NotificationTypes.VIOLATION.getValue());
         notificationBaseRequest.setEventName(String.format(String.format(violationEventName,annotation.get(POLICY_NAME))));
         notificationBaseRequest.setEventDescription(String.format(String.format(violationEventName,annotation.get(POLICY_NAME))));
+        notificationBaseRequest.setTenantId(tenantId);
 
         PolicyViolationNotificationRequest request = new PolicyViolationNotificationRequest();
         request.setIssueId(annotation.get(PacmanSdkConstants.ANNOTATION_PK));


### PR DESCRIPTION
## Description

Retrieve tenantId from params/environment, pass along in policy event



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced notification handling to support tenant-specific notifications by introducing tenant identification in notification requests.

* **Bug Fixes**
  * Ensured tenant information is consistently included in policy evaluation and notification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->