### PR TITLE
feat:[NEXT-1926] Added Optional tags to PolicyEngine

### DIFF
--- a/installer/resources/pacbot_app/files/DB.sql
+++ b/installer/resources/pacbot_app/files/DB.sql
@@ -125,6 +125,7 @@ SET @VULNERABILITY_SCHEDULE_COLLECTOR_INITIAL_DELAY='$VULNERABILITY_SCHEDULE_COL
 SET @VULNERABILITY_SCHEDULE_SHIPPER_INITIAL_DELAY='$VULNERABILITY_SCHEDULE_SHIPPER_INITIAL_DELAY';
 SET @ENABLE_EXTERNAL_ID='$ENABLE_EXTERNAL_ID';
 SET @EXTERNAL_ID='$EXTERNAL_ID';
+SET @OPTIONAL_TAGS='$OPTIONAL_TAGS';
 
 CREATE TABLE IF NOT EXISTS `OmniSearch_Config` (
   `SEARCH_CATEGORY` varchar(100) COLLATE utf8_bin NOT NULL,
@@ -3411,3 +3412,4 @@ UPDATE cf_pac_updatable_fields SET displayFields = CONCAT(displayFields, ',_asse
 
 update pac_v2_ui_options set optionURL='/compliance/v1/filters/attribute?ag=aws&attribute=_resourceid&type=issue', optionValue='_resourceid.keyword' where filterId=1 and optionName ="Asset ID";
 update pac_v2_ui_options set optionURL='/compliance/v1/filters/attribute?ag=aws&attribute=_resourceid&type=asset', optionValue='_resourceid.keyword' where filterId=8 and optionName ="Asset ID";
+INSERT IGNORE INTO pac_config_properties(`cfkey`,`value`,`application`,`profile`,`label`,`createdBy`,`createdDate`,`modifiedBy`,`modifiedDate`) VALUES ('tagging.optionalTags',concat(@OPTIONAL_TAGS,''),'application','prd','latest',NULL,NULL,NULL,NULL);

--- a/installer/settings/common.py
+++ b/installer/settings/common.py
@@ -162,7 +162,7 @@ DB_USERNAME = "paladin"
 DB_PASSWORD = "***PALADIN***" #Only printable ASCII characters besides '/', '@', '"', ' ' may be used.
 
 MANDATORY_TAGS = "Application,Environment"
-OPTIONAL_TAGS = "Name,env"
+OPTIONAL_TAGS = "Name,Env"
 # Add your first ACCOUNT_ID,ACCOUNT_NAME and ACCOUNT_PLATFORM here
 ACCOUNT_ID = ""
 ACCOUNT_NAME = ""

--- a/installer/settings/common.py
+++ b/installer/settings/common.py
@@ -162,6 +162,7 @@ DB_USERNAME = "paladin"
 DB_PASSWORD = "***PALADIN***" #Only printable ASCII characters besides '/', '@', '"', ' ' may be used.
 
 MANDATORY_TAGS = "Application,Environment"
+OPTIONAL_TAGS = "Name,env"
 # Add your first ACCOUNT_ID,ACCOUNT_NAME and ACCOUNT_PLATFORM here
 ACCOUNT_ID = ""
 ACCOUNT_NAME = ""

--- a/installer/settings/default.local.py
+++ b/installer/settings/default.local.py
@@ -85,6 +85,8 @@ JOB_SCHEDULER_NUMBER_OF_BATCHES = 20 #number of buckets for rules
 
 #mandatory tags for tagging polices
 MANDATORY_TAGS = "Application,Environment"
+#optinal tags for violation details.
+OPTIONAL_TAGS = "Name,Env"
 
 
 #BATCH CONFIGURATION 

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
@@ -707,4 +707,5 @@ public interface PacmanSdkConstants {
     String ASSET_STATE_JOB = "asset-state-job";
     String TENANT_CONFIG_TABLE = "tenant-config";
     String STATUS = "status";
+    String TAGGING_OPTIONAL_TAGS = "tagging.optionalTags";
 }

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/MultiThreadedPolicyRunner.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/MultiThreadedPolicyRunner.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.google.common.base.Strings;
 import com.tmobile.cloud.constants.PacmanRuleConstants;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
@@ -174,7 +173,9 @@ public class MultiThreadedPolicyRunner implements PolicyRunner {
                 // FINDING NON EVALUATED RESOURCES
             }
             String tagMandatory = policyParam.get(PacmanSdkConstants.TAGGING_MANDATORY_TAGS);
-            Map<String, String> mandatoryTags = getMandatoryTagsForAnnotation(tagMandatory,resource);
+            String tagOptional = policyParam.get(PacmanSdkConstants.TAGGING_OPTIONAL_TAGS);
+            Map<String, String> mandatoryTags = getTagsForAnnotation(tagMandatory,resource);
+            Map<String, String> optionalTags = getTagsForAnnotation(tagOptional,resource);
             // if fail issue will get logged to database, hence update the
             // category and severity
             if (PacmanSdkConstants.STATUS_FAILURE.equalsIgnoreCase(result.getStatus())
@@ -202,6 +203,7 @@ public class MultiThreadedPolicyRunner implements PolicyRunner {
                 result.getAnnotation().put(PacmanSdkConstants.ACCOUNT_ID, resource.get(PacmanRuleConstants.ACCOUNTID));
                 result.getAnnotation().put(PacmanSdkConstants.ACCOUNT_NAME, resource.get(PacmanRuleConstants.ACCOUNT_NAME));
                 mandatoryTags.forEach(result.getAnnotation()::putIfAbsent);
+                optionalTags.forEach(result.getAnnotation()::putIfAbsent);
 
             } else if (PacmanSdkConstants.STATUS_SUCCESS.equalsIgnoreCase(result.getStatus())) {
 
@@ -235,6 +237,7 @@ public class MultiThreadedPolicyRunner implements PolicyRunner {
                     annotation.put(PacmanSdkConstants.DOC_ID, resource.get(PacmanSdkConstants.DOC_ID));
                     annotation.put(PacmanSdkConstants.REGION, resource.get("region"));
                     mandatoryTags.forEach(annotation::putIfAbsent);
+                    optionalTags.forEach(annotation::putIfAbsent);
                 }
 
                 result.setAnnotation(annotation);

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -405,8 +405,10 @@ public class PolicyExecutor {
         final String type = CommonUtils.getPropValue(PacmanSdkConstants.STATS_TYPE_NAME_KEY); // "execution-stats";
         final String JOB_ID = CommonUtils.getEnvVariableValue(PacmanSdkConstants.JOB_ID);
         final String mandatoryTags = CommonUtils.getPropValue(PacmanSdkConstants.TAGGING_MANDATORY_TAGS);
+        final String optionalTags = CommonUtils.getPropValue(PacmanSdkConstants.TAGGING_OPTIONAL_TAGS);
         policyParam.put(PacmanSdkConstants.EXECUTION_ID, executionId);
         policyParam.put(PacmanSdkConstants.TAGGING_MANDATORY_TAGS, mandatoryTags);
+        policyParam.put(PacmanSdkConstants.TAGGING_OPTIONAL_TAGS, optionalTags);
         policyParam.put(PacmanSdkConstants.Role_IDENTIFYING_STRING, PacmanSdkConstants.ROLE_PREFIX +
                 PacmanSdkConstants.INTEGRAION_ROLE);
         if (Strings.isNullOrEmpty(policyParam.get(PacmanSdkConstants.DATA_SOURCE_KEY))) {

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyRunner.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyRunner.java
@@ -54,12 +54,12 @@ public interface PolicyRunner {
                 break;
         }
     }
-    default Map<String,String> getMandatoryTagsForAnnotation(String mandatoryTags, Map<String,String> resourceData){
-        if(mandatoryTags==null || mandatoryTags.isEmpty()){
+    default Map<String,String> getTagsForAnnotation(String tags, Map<String,String> resourceData){
+        if(tags==null || tags.isEmpty()){
             return Collections.emptyMap();
         }
         Map<String,String> annotationMap=new HashMap<>();
-        Set<String> mandatoryTagSet = Arrays.stream(mandatoryTags.split(",")).map(String::trim).collect(Collectors.toSet());
+        Set<String> mandatoryTagSet = Arrays.stream(tags.split(",")).map(String::trim).collect(Collectors.toSet());
         mandatoryTagSet.stream().forEach(element->{
             String tag="tags."+element;
             if(resourceData.containsKey(tag)){

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/SingleThreadPolicyRunner.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/SingleThreadPolicyRunner.java
@@ -22,9 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Strings;
 import com.tmobile.cloud.constants.PacmanRuleConstants;
-import com.tmobile.pacman.util.CommonUtils;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.slf4j.Logger;
@@ -38,7 +36,6 @@ import com.tmobile.pacman.commons.policy.PolicyResult;
 import com.tmobile.pacman.util.ReflectionUtils;
 import com.tmobile.pacman.util.PolicyExecutionUtils;
 
-import static com.tmobile.pacman.common.PacmanSdkConstants.JOB_NAME;
 import static com.tmobile.pacman.commons.PacmanSdkConstants.*;
 
 // TODO: Auto-generated Javadoc
@@ -123,7 +120,9 @@ public class SingleThreadPolicyRunner implements PolicyRunner {
                 // if fail issue will get logged to database, hence update the
                 // category and severity
                 String tagsMandatory = policyParam.get(PacmanSdkConstants.TAGGING_MANDATORY_TAGS);
-                Map<String, String> mandatoryTag = getMandatoryTagsForAnnotation(tagsMandatory,resource);
+                String tagOptional = policyParam.get(PacmanSdkConstants.TAGGING_OPTIONAL_TAGS);
+                Map<String, String> mandatoryTag = getTagsForAnnotation(tagsMandatory,resource);
+                Map<String, String> optionalTags = getTagsForAnnotation(tagOptional,resource);
                 if (result!= null && (PacmanSdkConstants.STATUS_FAILURE.equalsIgnoreCase(result.getStatus())
                         || PacmanSdkConstants.STATUS_UNKNOWN.equalsIgnoreCase(result.getStatus()))) {
                     if (policyParam.containsKey(PacmanSdkConstants.INVOCATION_ID)) {
@@ -151,6 +150,7 @@ public class SingleThreadPolicyRunner implements PolicyRunner {
                     result.getAnnotation().put(PacmanSdkConstants.ACCOUNT_NAME, resource.get(PacmanRuleConstants.ACCOUNT_NAME));
                     result.getAnnotation().put(PacmanRuleConstants.ACCOUNTID,resource.get(PacmanRuleConstants.ACCOUNTID));
                     mandatoryTag.forEach(result.getAnnotation()::putIfAbsent);
+                    optionalTags.forEach(result.getAnnotation()::putIfAbsent);
                 } else {
                     Annotation annotation = Annotation.buildAnnotation(policyParam, Annotation.Type.ISSUE);
                     annotation.put(PacmanSdkConstants.DATA_SOURCE_KEY,
@@ -170,6 +170,7 @@ public class SingleThreadPolicyRunner implements PolicyRunner {
                     annotation.put(PacmanSdkConstants.ACCOUNT_NAME, resource.get(PacmanRuleConstants.ACCOUNT_NAME));
                     annotation.put(PacmanSdkConstants.DOC_ID, resource.get(PacmanSdkConstants.DOC_ID)); // this is important to close the issue
                     mandatoryTag.forEach(annotation::putIfAbsent);
+                    optionalTags.forEach(annotation::putIfAbsent);
                     if (null != result) {
                         result.setAnnotation(annotation);
                     } else {


### PR DESCRIPTION
feat:[NEXT-1926] Added Optional tags to PolicyEngine

[NEXT-1926]: https://paladincloud.atlassian.net/browse/NEXT-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional tagging in resource annotations (Name, Env), alongside existing mandatory tags.

* **Chores**
  * Updated configuration and provisioning to store and expose optional tag settings.
  * Refactored tag-processing to merge mandatory and optional tags into annotations.

* **Bug Fixes**
  * Aligned Asset ID filter behavior for asset listings to ensure consistent asset lookup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->