### PR TITLE
feat:[PEA-358] Allow k8s lambda to assume 'ro' role

### DIFF
--- a/installer/resources/iam/all_read_role.py
+++ b/installer/resources/iam/all_read_role.py
@@ -8,7 +8,10 @@ class LambdaPolicyDocument(iam.IAMPolicyDocumentData):
             'actions': ["sts:AssumeRole"],
             'principals': {
                 'type': "AWS",
-                'identifiers': [ECSRole.get_output_attr('arn')]
+                'identifiers': [
+                    ECSRole.get_output_attr('arn'),
+                    "arn:aws:iam::" + Settings.ACCOUNT_ID + ":role/" + Settings.STACK_ENV + "-svc-plugin-k8s-containers-role"
+                ]
             }
         }
     ]


### PR DESCRIPTION
Add the k8s lambda role to the `ro` role, allowing the k8s lambda to assume the `PaladinCloudIntegrationRole` in the remote account, which is needed to get a valid K8s token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded role access so the service can assume permissions from an additional approved environment role.
  * Improved compatibility with Kubernetes container-based deployments by supporting both existing and new IAM role paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->