### PR TITLE
Change AssumeRoleRequest duration to 3600 seconds

### DIFF
--- a/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/config/CredentialProvider.java
+++ b/jobs/pacman-data-shipper/src/main/java/com/tmobile/cso/pacman/datashipper/config/CredentialProvider.java
@@ -42,7 +42,7 @@ public class CredentialProvider {
         }
         AWSSecurityTokenServiceClientBuilder stsBuilder = AWSSecurityTokenServiceClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(baseAccntCreds)).withRegion(baseRegion);
         AWSSecurityTokenService stsClient = stsBuilder.build();
-        AssumeRoleRequest assumeRequest = new AssumeRoleRequest().withRoleArn(getRoleArn(account, roleName)).withRoleSessionName("pic-ro-" + account).withDurationSeconds(7200);
+        AssumeRoleRequest assumeRequest = new AssumeRoleRequest().withRoleArn(getRoleArn(account, roleName)).withRoleSessionName("pic-ro-" + account).withDurationSeconds(3600);
         AssumeRoleResult assumeResult = stsClient.assumeRole(assumeRequest);
         return new BasicSessionCredentials(
                 assumeResult.getCredentials()
@@ -63,7 +63,7 @@ public class CredentialProvider {
             BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
             AWSSecurityTokenServiceClientBuilder stsBuilder = AWSSecurityTokenServiceClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(awsCreds)).withRegion(baseRegion);
             AWSSecurityTokenService sts = stsBuilder.build();
-            AssumeRoleRequest assumeRequest = new AssumeRoleRequest().withRoleArn(getRoleArn(baseAccount, roleName)).withRoleSessionName("pic-base-ro").withDurationSeconds(7200);
+            AssumeRoleRequest assumeRequest = new AssumeRoleRequest().withRoleArn(getRoleArn(baseAccount, roleName)).withRoleSessionName("pic-base-ro").withDurationSeconds(3600);
             AssumeRoleResult assumeResult = sts.assumeRole(assumeRequest);
             return new BasicSessionCredentials(
                     assumeResult.getCredentials().getAccessKeyId(), assumeResult.getCredentials().getSecretAccessKey(),
@@ -71,7 +71,7 @@ public class CredentialProvider {
 
         } else {
             AWSSecurityTokenService sts = AWSSecurityTokenServiceClientBuilder.defaultClient();
-            AssumeRoleRequest assumeRequest = new AssumeRoleRequest().withRoleArn(getRoleArn(baseAccount, roleName)).withRoleSessionName("pic-base-ro").withDurationSeconds(7200);
+            AssumeRoleRequest assumeRequest = new AssumeRoleRequest().withRoleArn(getRoleArn(baseAccount, roleName)).withRoleSessionName("pic-base-ro").withDurationSeconds(3600);
             AssumeRoleResult assumeResult = sts.assumeRole(assumeRequest);
             return new BasicSessionCredentials(
                     assumeResult.getCredentials().getAccessKeyId(), assumeResult.getCredentials().getSecretAccessKey(),


### PR DESCRIPTION
Change AssumeRoleRequest duration to 3600 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated role-assumption sessions to use a 1-hour duration, improving compatibility with credential session limits.
  * Applied the updated session duration consistently across direct and base account credential requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->