### PR TITLE
feat:[PEA-1473] account auto exemptions

### DIFF
--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/domain/ExemptionDTO.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/domain/ExemptionDTO.java
@@ -21,4 +21,5 @@ public class ExemptionDTO {
     private String exemptionCancelledOn;
     private String exemptionApprovedBy;
     private String exemptionApprovedOn;
+    private String exemptionType;
 }

--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/service/ComplianceServiceImpl.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/service/ComplianceServiceImpl.java
@@ -1576,6 +1576,9 @@ public class ComplianceServiceImpl implements ComplianceService, Constants {
                     .exemptionApprovedBy(Objects.isNull(policyViolationByIssueId.get(EXEMPTION_REQUEST_APPROVED_BY)) ?
                             StringUtils.EMPTY : String.valueOf(policyViolationByIssueId
                             .get(EXEMPTION_REQUEST_APPROVED_BY)))
+                    .exemptionType(Objects.isNull(policyViolationByIssueId.get(EXEMPTION_TYPE)) ?
+                            StringUtils.EMPTY : String.valueOf(policyViolationByIssueId
+                            .get(EXEMPTION_TYPE)))
                     .build();
             return new PolicyViolationDetails(policyViolationByIssueId.get(TARGET_TYPE).toString(),
                     policyViolationByIssueId.get(ISSUE_STATUS).toString(), policyViolationByIssueId.get(SEVERITY)

--- a/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
+++ b/commons/pac-api-commons/src/main/java/com/tmobile/pacman/api/commons/Constants.java
@@ -56,6 +56,7 @@ public interface Constants {
     String EXEMPTION_RAISED_ON = "exemption-raised-on";
     String EXEMPTION_EXPIRING_ON = "exemption-expiring-on";
     String EXEMPTION_RAISED_EXPIRING_ON = "exemption-raised-expiring-on";
+    String EXEMPTION_TYPE = "exemptionType";
 
     String REASON_TO_EXEMPT_KEY = "reason-to-exempt";
 

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/common/PacmanSdkConstants.java
@@ -113,6 +113,9 @@ public interface PacmanSdkConstants {
     /** The exemption id. */
     String EXEMPTION_ID = "exemptionId";
 
+    /** The exemption type. */
+    String EXEMPTION_TYPE = "exemptionType";
+
     /** The sev high. */
     String SEV_HIGH = "high";
 
@@ -282,6 +285,10 @@ public interface PacmanSdkConstants {
 
     /** The status unknown message. */
     String STATUS_UNKNOWN_MESSAGE = "unable to determine for this resource";
+
+    String EXEMPTION_TYPE_STICKY = "sticky";
+    String EXEMPTION_TYPE_INDIVIDUAL = "individual";
+    String EXEMPTION_TYPE_AUTOMATIC = "automatic";
 
     /** The max policy executor threads. */
     Integer MAX_POLICY_EXECUTOR_THREADS = 100;

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -44,6 +44,7 @@ import com.tmobile.pacman.commons.utils.Constants;
 import com.tmobile.pacman.dto.IssueException;
 import com.tmobile.pacman.integrations.slack.SlackMessageRelay;
 import com.tmobile.pacman.publisher.impl.AnnotationPublisher;
+import com.tmobile.pacman.service.AutoExemptions;
 import com.tmobile.pacman.service.ExceptionManager;
 import com.tmobile.pacman.service.ExceptionManagerImpl;
 import com.tmobile.pacman.util.*;
@@ -531,7 +532,6 @@ public class PolicyExecutor {
         // process rule evaluations the annotations based on result
         try {
             if (evaluations.size() > 0) {
-
                 ExceptionManager exceptionManager = new ExceptionManagerImpl();
                 Map<String, List<IssueException>> exemptedResourcesForPolicy = exceptionManager.getStickyExceptions(
                         policyParam.get(PacmanSdkConstants.POLICY_ID), policyParam.get(PacmanSdkConstants.TARGET_TYPE));
@@ -539,7 +539,7 @@ public class PolicyExecutor {
                         .getIndividualExceptions(policyParam.get(PacmanSdkConstants.TARGET_TYPE));
 
                 policyEngineStats.putAll(processPolicyEvaluations(resources, evaluations, policyParam,
-                        exemptedResourcesForPolicy, individuallyExemptedIssues));
+                        exemptedResourcesForPolicy, individuallyExemptedIssues, resourceIdToResourceMap));
                 try {
                     if (policyParam.containsKey(PacmanSdkConstants.POLICY_PARAM_AUTO_FIX_KEY_NAME) && Boolean
                             .parseBoolean(policyParam.get(PacmanSdkConstants.POLICY_PARAM_AUTO_FIX_KEY_NAME))) {
@@ -646,7 +646,8 @@ public class PolicyExecutor {
     private Map<String, Object> processPolicyEvaluations(List<Map<String, String>> resources,
                                                          List<PolicyResult> evaluations, Map<String, String> policyParam,
                                                          Map<String, List<IssueException>> exemptedResourcesForPolicy,
-                                                         Map<String, IssueException> individuallyExcemptedIssues) throws Exception {
+                                                         Map<String, IssueException> individuallyExcemptedIssues,
+                                                         Map<String, Map<String, String>> resourceIdToAsset) throws Exception {
 
         Map<String, Object> metrics = new HashMap();
         metrics.put("totalResourcesEvalauted", evaluations.size());
@@ -658,23 +659,26 @@ public class PolicyExecutor {
         List<Annotation> revokedExemptions = new ArrayList<>();
         AnnotationPublisher annotationPublisher = new AnnotationPublisher();
         long exemptionCounter = 0;
+
         try {
-
             metrics.put("max-exemptible-resource-count", exemptedResourcesForPolicy.size());
-
             metrics.put("individual-exception-count-for-this-policy", individuallyExcemptedIssues.size());
         } catch (Exception e) {
-            logger.error("unable to fetch exceptions", e);
+            logger.error("unable to update exception metrics", e);
         }
+
         Status status;
         int issueFoundCounter = 0;
         //Pre populate the existing issues
         annotationPublisher.populateExistingIssuesForType(policyParam);
 
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(policyParam);
+
         /** collect previous status of issues to determine audit statuses **/
         Map<String, Map<String, String>> originalIssueStatuses = new HashMap<>(evaluations.size());
         for (PolicyResult result : evaluations) {
             annotation = result.getAnnotation();
+            Map<String, String> asset = resourceIdToAsset.get(annotation.get("_docid"));
             String _id = CommonUtils.getUniqueAnnotationId(annotation);
             Map<String, String> originalIssue = annotationPublisher.getExistingIssuesMapWithAnnotationIdAsKey().get(_id);
             if (originalIssue != null) {
@@ -691,7 +695,7 @@ public class PolicyExecutor {
                 if (PacmanSdkConstants.STATUS_FAILURE.equals(result.getStatus())) {
 
                     status = adjustStatus(PacmanSdkConstants.STATUS_OPEN, exemptedResourcesForPolicy,
-                            individuallyExcemptedIssues, annotation);
+                            individuallyExcemptedIssues, rule, annotation, asset);
                     annotation.put(PacmanSdkConstants.ISSUE_STATUS_KEY, status.getStatus());
 
                     // if exempted add additional details
@@ -732,7 +736,7 @@ public class PolicyExecutor {
             /*  collect all revoked exemptions to create ticket for JIRA / ServiceNow for MTN */
             if(originalIssue != null && PacmanSdkConstants.STATUS_EXEMPTED.equals(originalIssue.get(PacmanSdkConstants.ISSUE_STATUS_KEY) )){
                 Status currentStatus = adjustStatus(PacmanSdkConstants.STATUS_OPEN, exemptedResourcesForPolicy,
-                        individuallyExcemptedIssues, annotation);
+                        individuallyExcemptedIssues, rule, annotation, asset);
                 if( currentStatus.status.equalsIgnoreCase(PacmanSdkConstants.STATUS_OPEN))
                 {
                     revokedExemptions.add(annotation);
@@ -826,26 +830,37 @@ public class PolicyExecutor {
      * @return the status
      */
     private Status adjustStatus(String status, Map<String, List<IssueException>> excemptedResourcesForPolicy,
-                                Map<String, IssueException> individuallyExcemptedIssues, Annotation annotation) {
+                                Map<String, IssueException> individuallyExcemptedIssues,
+                                AutoExemptions.Rule rule,
+                                Annotation annotation,
+                                Map<String, String> asset) {
 
         List<IssueException> stickyExceptions = excemptedResourcesForPolicy
                 .get(annotation.get(PacmanSdkConstants.RESOURCE_ID));
-        IssueException exception;
         if (null != stickyExceptions) {
             // get the exemption with min expiry date and create the status for
             // now taking from 0 index
-            exception = stickyExceptions.get(0);
+            IssueException exception = stickyExceptions.get(0);
             return new Status(PacmanSdkConstants.STATUS_EXEMPTED, exception.getExceptionReason(), exception.getId(),
                     exception.getExpiryDate());
-        } else // check individual exception
-        {
-            exception = individuallyExcemptedIssues.get(CommonUtils.getUniqueAnnotationId(annotation));
-            if (null != exception) {
-                return new Status(PacmanSdkConstants.STATUS_EXEMPTED, exception.getExceptionReason(), exception.getId(), exception.getExpiryDate());
-            } else {
-                return new Status(status); // return the same status as input
+        }
+
+        IssueException exception = individuallyExcemptedIssues.get(CommonUtils.getUniqueAnnotationId(annotation));
+        if (null != exception) {
+            return new Status(PacmanSdkConstants.STATUS_EXEMPTED, exception.getExceptionReason(), exception.getId(), exception.getExpiryDate());
+        }
+
+        if (rule != null) {
+            if (rule.isExempted(asset)) {
+                return new Status(
+                        PacmanSdkConstants.STATUS_EXEMPTED,
+                        rule.getReason(),
+                        // TODO: Figure out what this id really is
+                        "1",
+                        rule.getExpireDate());
             }
         }
+        return new Status(status);
     }
 
     /**

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -704,6 +704,7 @@ public class PolicyExecutor {
                         annotation.put(PacmanSdkConstants.EXEMPTION_EXPIRING_ON, status.getExemptionExpiryDate());
                         annotation.put(PacmanSdkConstants.REASON_TO_EXEMPT_KEY, status.getReason());
                         annotation.put(PacmanSdkConstants.EXEMPTION_ID, status.getExceptionId());
+                        annotation.put(PacmanSdkConstants.EXEMPTION_TYPE, status.getExemptionType());
                     }
 
                     /** close expired exemption request made by user **/
@@ -835,7 +836,6 @@ public class PolicyExecutor {
                                 Annotation annotation,
                                 Map<String, String> asset) {
 
-logger.info("adjustStatus for asset {}", asset.get("_resourceid"));
         List<IssueException> stickyExceptions = excemptedResourcesForPolicy
                 .get(annotation.get(PacmanSdkConstants.RESOURCE_ID));
         if (null != stickyExceptions) {
@@ -843,12 +843,13 @@ logger.info("adjustStatus for asset {}", asset.get("_resourceid"));
             // now taking from 0 index
             IssueException exception = stickyExceptions.get(0);
             return new Status(PacmanSdkConstants.STATUS_EXEMPTED, exception.getExceptionReason(), exception.getId(),
-                    exception.getExpiryDate());
+                    exception.getExpiryDate(), PacmanSdkConstants.EXEMPTION_TYPE_STICKY);
         }
 
         IssueException exception = individuallyExcemptedIssues.get(CommonUtils.getUniqueAnnotationId(annotation));
         if (null != exception) {
-            return new Status(PacmanSdkConstants.STATUS_EXEMPTED, exception.getExceptionReason(), exception.getId(), exception.getExpiryDate());
+            return new Status(PacmanSdkConstants.STATUS_EXEMPTED, exception.getExceptionReason(), exception.getId(),
+                    exception.getExpiryDate(), PacmanSdkConstants.EXEMPTION_TYPE_INDIVIDUAL);
         }
 
         if (autoExemptionRule != null) {
@@ -856,10 +857,9 @@ logger.info("adjustStatus for asset {}", asset.get("_resourceid"));
                 return new Status(
                         PacmanSdkConstants.STATUS_EXEMPTED,
                         "Auto-exempted: " + autoExemptionRule.getReason(),
-                        // TODO: Figure out what this id really is
-                        // USE THE POLICY ID ?
-                        "1",
-                        autoExemptionRule.getExpireDate());
+                        annotation.get(PacmanSdkConstants.POLICY_ID),
+                        autoExemptionRule.getExpireDate(),
+                        PacmanSdkConstants.EXEMPTION_TYPE_AUTOMATIC);
             }
         }
         return new Status(status);
@@ -890,6 +890,8 @@ logger.info("adjustStatus for asset {}", asset.get("_resourceid"));
         /** The exemption expiry date. */
         String exemptionExpiryDate;
 
+        String exemptionType;
+
         /**
          * Instantiates a new status.
          *
@@ -898,12 +900,13 @@ logger.info("adjustStatus for asset {}", asset.get("_resourceid"));
          * @param exemptionId the exemption id
          * @param exemptionExpiryDate the exemption expiry date
          */
-        public Status(String status, String reason, String exemptionId, String exemptionExpiryDate) {
+        public Status(String status, String reason, String exemptionId, String exemptionExpiryDate, String exemptionType) {
             super();
             this.status = status;
             this.reason = reason;
             this.exemptionId = exemptionId;
             this.exemptionExpiryDate = exemptionExpiryDate;
+            this.exemptionType = exemptionType;
         }
 
         /**
@@ -1003,6 +1006,10 @@ logger.info("adjustStatus for asset {}", asset.get("_resourceid"));
          */
         public void setExemptionExpiryDate(String exemptionExpiryDate) {
             this.exemptionExpiryDate = exemptionExpiryDate;
+        }
+
+        public String getExemptionType() {
+            return this.exemptionType;
         }
     }
 

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/executor/PolicyExecutor.java
@@ -831,10 +831,11 @@ public class PolicyExecutor {
      */
     private Status adjustStatus(String status, Map<String, List<IssueException>> excemptedResourcesForPolicy,
                                 Map<String, IssueException> individuallyExcemptedIssues,
-                                AutoExemptions.Rule rule,
+                                AutoExemptions.Rule autoExemptionRule,
                                 Annotation annotation,
                                 Map<String, String> asset) {
 
+logger.info("adjustStatus for asset {}", asset.get("_resourceid"));
         List<IssueException> stickyExceptions = excemptedResourcesForPolicy
                 .get(annotation.get(PacmanSdkConstants.RESOURCE_ID));
         if (null != stickyExceptions) {
@@ -850,14 +851,15 @@ public class PolicyExecutor {
             return new Status(PacmanSdkConstants.STATUS_EXEMPTED, exception.getExceptionReason(), exception.getId(), exception.getExpiryDate());
         }
 
-        if (rule != null) {
-            if (rule.isExempted(asset)) {
+        if (autoExemptionRule != null) {
+            if (autoExemptionRule.isExempted(asset)) {
                 return new Status(
                         PacmanSdkConstants.STATUS_EXEMPTED,
-                        rule.getReason(),
+                        "Auto-exempted: " + autoExemptionRule.getReason(),
                         // TODO: Figure out what this id really is
+                        // USE THE POLICY ID ?
                         "1",
-                        rule.getExpireDate());
+                        autoExemptionRule.getExpireDate());
             }
         }
         return new Status(status);

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/service/AutoExemptions.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/service/AutoExemptions.java
@@ -1,0 +1,90 @@
+package com.tmobile.pacman.service;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class AutoExemptions {
+    static public final String PARAMS_ENABLED_FIELD = "isExemptionEnabled";
+    static public final String PARAMS_EXPIRE_DATE_FIELD = "exemptionexpireddate";
+    static public final String PARAMS_REASON_FIELD = "exemptionReason";
+    static public final String PARAMS_ACCOUNTS_FIELD = "exemptionAccounts";
+
+
+    static public Rule ruleFromPolicyParams(Map<String, String> params) {
+        String enabledStr = params.getOrDefault(PARAMS_ENABLED_FIELD, "false").toLowerCase();
+
+        String expireDate = params.getOrDefault(PARAMS_EXPIRE_DATE_FIELD, null);
+        String reason = params.getOrDefault(PARAMS_REASON_FIELD, "");
+
+        String accountsStr = params.getOrDefault(PARAMS_ACCOUNTS_FIELD, "");
+        List<String> accounts = Arrays.asList(accountsStr.split(",")).stream()
+                .map(s -> s.trim())
+                .collect(Collectors.toList());
+
+        return new Rule(
+                Boolean.parseBoolean(enabledStr),
+                expireDate,
+                reason,
+                accounts);
+    }
+
+    static public class Rule {
+        protected boolean enabled;
+        protected String expireDate;
+        protected String reason;
+        protected List<String> accounts;
+
+        static private SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+        static {
+            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        }
+
+        public Rule(boolean enabled, String expireDate, String reason, List<String> accounts) {
+            this.enabled = enabled;
+            this.expireDate = expireDate;
+            this.reason = reason;
+            this.accounts = accounts;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+
+        public String getExpireDate() {
+            return expireDate;
+        }
+
+        public boolean isExempted(Map<String, String> asset) {
+            if (asset == null) {
+                return false;
+            }
+
+            if (!this.enabled) {
+                return false;
+            }
+
+            if (this.expireDate != null && !this.expireDate.isEmpty()) {
+                String today = sdf.format(new Date());
+                if (today.compareTo(this.expireDate) > 0) {
+                    return false;
+                }
+            }
+
+            if (accounts.contains(getAccountId(asset))) {
+                return true;
+            }
+
+            return false;
+        }
+
+        private String getAccountId(Map<String, String> asset) {
+            String id = asset.getOrDefault("account_id", null);
+            if (id == null || id.isEmpty()) {
+                id = asset.getOrDefault("accountid", null);
+            }
+
+            return id;
+        }
+    }
+}

--- a/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsTest.java
+++ b/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsTest.java
@@ -23,6 +23,14 @@ public class AutoExemptionsTest {
     }
 
     @Test
+    public void testAccountWithSpaceIsExempted() throws Exception {
+        Map<String, String> asset = mapOf("accountid", "234");
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", "123, 234 ,345 "));
+        boolean check = rule.isExempted(asset);
+        assertTrue(check);
+    }
+
+    @Test
     public void testDisabledIsNotExempted() throws Exception {
         Map<String, String> asset = mapOf("accountid", "345");
         AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("false", null, "guppies", "123,234,345"));

--- a/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsTest.java
+++ b/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsTest.java
@@ -1,0 +1,94 @@
+package com.tmobile.pacman.service;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AutoExemptionsTest {
+    static private SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+    static {
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    @Test
+    public void testAccountMatchIsExempted() throws Exception {
+        Map<String, String> asset = mapOf("accountid", "345");
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", "123,234,345"));
+        boolean check = rule.isExempted(asset);
+        assertTrue(check);
+    }
+
+    @Test
+    public void testDisabledIsNotExempted() throws Exception {
+        Map<String, String> asset = mapOf("accountid", "345");
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("false", null, "guppies", "123,234,345"));
+        boolean check = rule.isExempted(asset);
+        assertFalse(check);
+    }
+
+    @Test
+    public void testNoAccountMatchIsNotExempted() throws Exception {
+        Map<String, String> asset = mapOf("accountid", "789");
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "toads", "123,234,345"));
+        boolean check = rule.isExempted(asset);
+        assertFalse(check);
+    }
+
+    @Test
+    public void testFutureDateIsExempted() throws Exception {
+        Map<String, String> asset = mapOf("accountid", "345");
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", adjustDate(new Date(), 1), "frogs", "123,234,345"));
+        boolean check = rule.isExempted(asset);
+        assertTrue(check);
+    }
+
+    @Test
+    public void testTodayIsExempted() throws Exception {
+        Map<String, String> asset = mapOf("accountid", "345");
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", adjustDate(new Date(), 0), "frogs", "123,234,345"));
+        boolean check = rule.isExempted(asset);
+        assertTrue(check);
+    }
+
+    @Test
+    public void testPastDateIsNotExempted() throws Exception {
+        Map<String, String> asset = mapOf("accountid", "345");
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", adjustDate(new Date(), -1), "frogs", "123,234,345"));
+        boolean check = rule.isExempted(asset);
+        assertFalse(check);
+    }
+
+    @Test
+    public void testBlankDateIsIgnored() throws Exception {
+        Map<String, String> asset = mapOf("accountid", "345");
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", "", "frogs", "123,234,345"));
+        boolean check = rule.isExempted(asset);
+        assertTrue(check);
+    }
+
+    private Map<String, String> mapOf(String key, String value) {
+        Map<String, String> map = new HashMap();
+        map.put(key, value);
+        return map;
+    }
+
+    private Map<String, String> params(String enabled, String date, String reason, String accounts) {
+        Map<String, String> map = new HashMap();
+        map.put(AutoExemptions.PARAMS_ENABLED_FIELD, enabled);
+        map.put(AutoExemptions.PARAMS_EXPIRE_DATE_FIELD, date);
+        map.put(AutoExemptions.PARAMS_REASON_FIELD, reason);
+        map.put(AutoExemptions.PARAMS_ACCOUNTS_FIELD, accounts);
+        return map;
+    }
+
+    public static String adjustDate(Date dt, int amount) {
+        Calendar calendarDate = Calendar.getInstance();
+        calendarDate.setTime(dt);
+        calendarDate.add(Calendar.DATE, amount);
+        return sdf.format(calendarDate.getTime());
+    }
+}


### PR DESCRIPTION
Adds auto-exemptions based off matching the account id. This is the first step in auto-exemptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added policy-driven automatic exemptions based on account, enablement, and expiration settings.
  - Exemption results now identify their type: sticky, individual, or automatic.
  - Exemption type details are included in policy violation information.

- **Bug Fixes**
  - Expired automatic exemptions are no longer applied.
  - Account matching supports standard account identifier formats and whitespace variations.

- **Tests**
  - Added coverage for account matching, disabled rules, expiration dates, and exemption classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->