### PR TITLE
feat:[PEA-1417] tag auto exemptions

### DIFF
--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/service/AutoExemptions.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/service/AutoExemptions.java
@@ -24,7 +24,7 @@ public class AutoExemptions {
 
         // If both accounts and rules field are set, default to using the rules
         String rulesStr = params.getOrDefault(PARAMS_RULES_FIELD, null);
-        if (rulesStr != null) {
+        if (rulesStr != null && !rulesStr.isEmpty()) {
             // json array, each entry is a clause - any clause that's true is a match.
             // within a clause, each property must be true
             Gson gson = new Gson();
@@ -109,8 +109,8 @@ public class AutoExemptions {
                         matchExplanation = String.format("Matches clause #%d", idx + 1);
                         return true;
                     }
-                    matchExplanation = "No clauses matched";
                 }
+                matchExplanation = "No clauses matched";
             } else if (accounts != null) {
                 String accountId = getAccountId(asset);
                 if (accounts.contains(accountId)) {

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/service/AutoExemptions.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/service/AutoExemptions.java
@@ -1,6 +1,7 @@
 package com.tmobile.pacman.service;
 
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import lombok.Getter;
 
 import java.text.SimpleDateFormat;
@@ -27,7 +28,7 @@ public class AutoExemptions {
             // json array, each entry is a clause - any clause that's true is a match.
             // within a clause, each property must be true
             Gson gson = new Gson();
-            List<Map<String, Object>> clauses = gson.fromJson(rulesStr, List.class);
+            List<Map<String, Object>> clauses = gson.fromJson(rulesStr,new TypeToken<List<Map<String, Object>>>(){}.getType());
             return Rule.createRulesWithClauses(
                     Boolean.parseBoolean(enabledStr),
                     expireDate,

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/service/AutoExemptions.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/service/AutoExemptions.java
@@ -1,5 +1,8 @@
 package com.tmobile.pacman.service;
 
+import com.google.gson.Gson;
+import lombok.Getter;
+
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -9,6 +12,7 @@ public class AutoExemptions {
     static public final String PARAMS_EXPIRE_DATE_FIELD = "exemptionexpireddate";
     static public final String PARAMS_REASON_FIELD = "exemptionReason";
     static public final String PARAMS_ACCOUNTS_FIELD = "exemptionAccounts";
+    static public final String PARAMS_RULES_FIELD = "exemptionRules";
 
 
     static public Rule ruleFromPolicyParams(Map<String, String> params) {
@@ -17,65 +21,128 @@ public class AutoExemptions {
         String expireDate = params.getOrDefault(PARAMS_EXPIRE_DATE_FIELD, null);
         String reason = params.getOrDefault(PARAMS_REASON_FIELD, "");
 
-        String accountsStr = params.getOrDefault(PARAMS_ACCOUNTS_FIELD, "");
-        List<String> accounts = Arrays.asList(accountsStr.split(",")).stream()
-                .map(s -> s.trim())
-                .collect(Collectors.toList());
+        // If both accounts and rules field are set, default to using the rules
+        String rulesStr = params.getOrDefault(PARAMS_RULES_FIELD, null);
+        if (rulesStr != null) {
+            // json array, each entry is a clause - any clause that's true is a match.
+            // within a clause, each property must be true
+            Gson gson = new Gson();
+            List<Map<String, Object>> clauses = gson.fromJson(rulesStr, List.class);
+            return Rule.createRulesWithClauses(
+                    Boolean.parseBoolean(enabledStr),
+                    expireDate,
+                    reason,
+                    clauses);
+        } else {
+            String accountsStr = params.getOrDefault(PARAMS_ACCOUNTS_FIELD, "");
+            List<String> accounts = Arrays.stream(accountsStr.split(","))
+                    .map(String::trim)
+                    .collect(Collectors.toList());
 
-        return new Rule(
-                Boolean.parseBoolean(enabledStr),
-                expireDate,
-                reason,
-                accounts);
+            return Rule.createAccountsRule(
+                    Boolean.parseBoolean(enabledStr),
+                    expireDate,
+                    reason,
+                    accounts);
+        }
     }
 
     static public class Rule {
         protected boolean enabled;
+        @Getter
         protected String expireDate;
+        @Getter
         protected String reason;
         protected List<String> accounts;
+        protected List<Map<String, Object>> clauses;
 
-        static private SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+        @Getter
+        protected String matchExplanation;
+
+        static private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
         static {
             sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         }
 
-        public Rule(boolean enabled, String expireDate, String reason, List<String> accounts) {
+        static Rule createAccountsRule(boolean enabled, String expireDate, String reason, List<String> accounts) {
+            Rule rule = new Rule(enabled, expireDate, reason);
+            rule.accounts = accounts;
+            return rule;
+        }
+
+        static Rule createRulesWithClauses(boolean enabled, String expireDate, String reason, List<Map<String, Object>> clauses) {
+            Rule rule = new Rule(enabled, expireDate, reason);
+            rule.clauses = clauses;
+            return rule;
+        }
+
+        private Rule(boolean enabled, String expireDate, String reason) {
             this.enabled = enabled;
             this.expireDate = expireDate;
             this.reason = reason;
-            this.accounts = accounts;
-        }
-
-        public String getReason() {
-            return reason;
-        }
-
-        public String getExpireDate() {
-            return expireDate;
         }
 
         public boolean isExempted(Map<String, String> asset) {
             if (asset == null) {
+                matchExplanation = "Invalid asset";
                 return false;
             }
 
             if (!this.enabled) {
+                matchExplanation = "Rule is disabled";
                 return false;
             }
 
             if (this.expireDate != null && !this.expireDate.isEmpty()) {
                 String today = sdf.format(new Date());
                 if (today.compareTo(this.expireDate) > 0) {
+                    matchExplanation = "Rule has expired";
                     return false;
                 }
             }
 
-            if (accounts.contains(getAccountId(asset))) {
-                return true;
+            if (clauses != null) {
+                for (int idx = 0; idx < clauses.size(); idx++) {
+                    Map<String, Object> clause = clauses.get(idx);
+                    if (doesClauseMatch(clause, asset)) {
+                        matchExplanation = String.format("Matches clause #%d", idx + 1);
+                        return true;
+                    }
+                    matchExplanation = "No clauses matched";
+                }
+            } else if (accounts != null) {
+                String accountId = getAccountId(asset);
+                if (accounts.contains(accountId)) {
+                    matchExplanation = String.format("Matches account %s", accountId);
+                    return true;
+                }
+
+                matchExplanation = "No accounts match";
             }
 
             return false;
+        }
+
+        private boolean doesClauseMatch(Map<String, Object> clause, Map<String, String> asset) {
+            if (clauses.isEmpty()) {
+                return false;
+            }
+
+            for (Map.Entry<String, Object> entry : clause.entrySet()) {
+                Object assetValue = getAssetField(entry.getKey(), asset);
+                if (!entry.getValue().equals(assetValue)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private Object getAssetField(String field, Map<String, String> asset) {
+            if (field.equals("accountid")) {
+                return asset.getOrDefault("account_id", asset.get("accountid"));
+            }
+            return asset.get(field);
         }
 
         private String getAccountId(Map<String, String> asset) {

--- a/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsAccountsTest.java
+++ b/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsAccountsTest.java
@@ -4,12 +4,11 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-public class AutoExemptionsTest {
-    static private SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+import static org.junit.Assert.*;
+
+public class AutoExemptionsAccountsTest {
+    static private final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
     static {
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
@@ -20,6 +19,7 @@ public class AutoExemptionsTest {
         AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", "123,234,345"));
         boolean check = rule.isExempted(asset);
         assertTrue(check);
+        assertEquals("Matches account 345", rule.getMatchExplanation());
     }
 
     @Test
@@ -27,6 +27,7 @@ public class AutoExemptionsTest {
         Map<String, String> asset = mapOf("accountid", "234");
         AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", "123, 234 ,345 "));
         boolean check = rule.isExempted(asset);
+        assertEquals("Matches account 234", rule.getMatchExplanation());
         assertTrue(check);
     }
 
@@ -36,6 +37,7 @@ public class AutoExemptionsTest {
         AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("false", null, "guppies", "123,234,345"));
         boolean check = rule.isExempted(asset);
         assertFalse(check);
+        assertEquals("Rule is disabled", rule.getMatchExplanation());
     }
 
     @Test
@@ -44,6 +46,7 @@ public class AutoExemptionsTest {
         AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "toads", "123,234,345"));
         boolean check = rule.isExempted(asset);
         assertFalse(check);
+        assertEquals("No accounts match", rule.getMatchExplanation());
     }
 
     @Test
@@ -68,6 +71,7 @@ public class AutoExemptionsTest {
         AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", adjustDate(new Date(), -1), "frogs", "123,234,345"));
         boolean check = rule.isExempted(asset);
         assertFalse(check);
+        assertEquals("Rule has expired", rule.getMatchExplanation());
     }
 
     @Test
@@ -79,13 +83,13 @@ public class AutoExemptionsTest {
     }
 
     private Map<String, String> mapOf(String key, String value) {
-        Map<String, String> map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         map.put(key, value);
         return map;
     }
 
     private Map<String, String> params(String enabled, String date, String reason, String accounts) {
-        Map<String, String> map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         map.put(AutoExemptions.PARAMS_ENABLED_FIELD, enabled);
         map.put(AutoExemptions.PARAMS_EXPIRE_DATE_FIELD, date);
         map.put(AutoExemptions.PARAMS_REASON_FIELD, reason);

--- a/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsClausesTest.java
+++ b/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsClausesTest.java
@@ -23,6 +23,17 @@ public class AutoExemptionsClausesTest {
     }
 
     @Test
+    public void testTwoTagsIsExempted() throws Exception {
+        Map<String, String> asset = mapOf("tags.component", "EFS", "tags.app", "Purchase", "account_id", "345");
+        List<Map<String, Object>> clauses = Arrays.asList(
+                clauseOf("tags.app", "Purchase", "tags.component", "EFS"));
+
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", toJson(clauses)));
+        boolean check = rule.isExempted(asset);
+        assertTrue(check);
+        assertEquals("Matches clause #1", rule.getMatchExplanation());
+    }
+    @Test
     public void testOneClause2FieldsIsExempted() throws Exception {
         Map<String, String> asset = mapOf("accountid", "345", "tags.component", "EFS");
         List<Map<String, Object>> clauses = Arrays.asList(
@@ -117,5 +128,10 @@ public class AutoExemptionsClausesTest {
         return map;
     }
 
+    private Map<String, String> mapOf(String key1, String value1, String key2, String value2, String key3, String value3) {
+        Map<String, String> map = mapOf(key1, value1, key2, value2);
+        map.put(key3, value3);
+        return map;
+    }
 
 }

--- a/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsClausesTest.java
+++ b/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsClausesTest.java
@@ -11,6 +11,15 @@ import static org.junit.Assert.assertTrue;
 
 public class AutoExemptionsClausesTest {
     @Test
+    public void testOEmptyRuleNotExempted() throws Exception {
+        Map<String, String> asset = mapOf("account_id", "345", "tags.component", "EFS");
+        List<Map<String, Object>> clauses = Arrays.asList();
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", toJson(clauses)));
+        boolean check = rule.isExempted(asset);
+        assertFalse(check);
+        assertEquals("No clauses matched", rule.getMatchExplanation());
+    }
+    @Test
     public void testOneClauseOneFieldIsExempted() throws Exception {
         Map<String, String> asset = mapOf("account_id", "345", "tags.component", "EFS");
         List<Map<String, Object>> clauses = Arrays.asList(

--- a/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsClausesTest.java
+++ b/jobs/pacman-rule-engine-2.0/src/test/java/com/tmobile/pacman/service/AutoExemptionsClausesTest.java
@@ -1,0 +1,121 @@
+package com.tmobile.pacman.service;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AutoExemptionsClausesTest {
+    @Test
+    public void testOneClauseOneFieldIsExempted() throws Exception {
+        Map<String, String> asset = mapOf("account_id", "345", "tags.component", "EFS");
+        List<Map<String, Object>> clauses = Arrays.asList(
+                clauseOf("accountid", "345"));
+
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", toJson(clauses)));
+        boolean check = rule.isExempted(asset);
+        assertTrue(check);
+        assertEquals("Matches clause #1", rule.getMatchExplanation());
+    }
+
+    @Test
+    public void testOneClause2FieldsIsExempted() throws Exception {
+        Map<String, String> asset = mapOf("accountid", "345", "tags.component", "EFS");
+        List<Map<String, Object>> clauses = Arrays.asList(
+                clauseOf("accountid", "345", "tags.component", "EFS"));
+
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", toJson(clauses)));
+        boolean check = rule.isExempted(asset);
+        assertTrue(check);
+    }
+
+    @Test
+    public void testTwoClause2FieldsIsExempted() throws Exception {
+        Map<String, String> asset = mapOf("account_id", "345", "tags.component", "EFS");
+        List<Map<String, Object>> clauses = Arrays.asList(
+                clauseOf("accountid", "192", "tags.component", "EFS"),
+                clauseOf("accountid", "345", "tags.component", "EFS"));
+
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", toJson(clauses)));
+        boolean check = rule.isExempted(asset);
+        assertTrue(check);
+    }
+
+    @Test
+    public void testManyClause2FieldsIsExempted() throws Exception {
+        Map<String, String> asset = mapOf("account_id", "345", "tags.component", "EFS");
+        List<Map<String, Object>> clauses = Arrays.asList(
+                clauseOf("accountid", "193", "tags.component", "EFS"),
+                clauseOf("accountid", "194", "tags.component", "EFS"),
+                clauseOf("accountid", "195", "tags.component", "EFS"),
+                clauseOf("accountid", "196", "tags.component", "EFS"),
+                clauseOf("accountid", "197", "tags.component", "EFS"),
+                clauseOf("accountid", "198", "tags.component", "EFS"),
+                clauseOf("accountid", "199", "tags.component", "EFS"),
+                clauseOf("accountid", "200", "tags.component", "EFS"),
+                clauseOf("accountid", "201", "tags.component", "EFS"),
+                clauseOf("accountid", "345", "tags.component", "EFS"));
+
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", toJson(clauses)));
+        boolean check = rule.isExempted(asset);
+        assertTrue(check);
+        assertEquals("Matches clause #10", rule.getMatchExplanation());
+    }
+
+    @Test
+    public void testOneClauseNoMatchIsNotExempted() throws Exception {
+        Map<String, String> asset = mapOf("account_id", "345", "tags.component", "EFS");
+        List<Map<String, Object>> clauses = Arrays.asList(clauseOf("accountid", "193", "tags.component", "EFS"));
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", toJson(clauses)));
+        boolean check = rule.isExempted(asset);
+        assertFalse(check);
+    }
+
+    @Test
+    public void testNoClauseIsNotExempted() throws Exception {
+        Map<String, String> asset = mapOf("account_id", "345", "tags.component", "EFS");
+        List<Map<String, Object>> clauses = Arrays.asList();
+        AutoExemptions.Rule rule = AutoExemptions.ruleFromPolicyParams(params("true", null, "goldfish", toJson(clauses)));
+        boolean check = rule.isExempted(asset);
+        assertFalse(check);
+    }
+
+    private Map<String, String> params(String enabled, String date, String reason, String rules) {
+        Map<String, String> map = new HashMap<>();
+        map.put(AutoExemptions.PARAMS_ENABLED_FIELD, enabled);
+        map.put(AutoExemptions.PARAMS_EXPIRE_DATE_FIELD, date);
+        map.put(AutoExemptions.PARAMS_REASON_FIELD, reason);
+        map.put(AutoExemptions.PARAMS_RULES_FIELD, rules);
+        return map;
+    }
+
+    private String toJson(List<Map<String,Object>> clauses) {
+        Gson gson = new Gson();
+        return gson.toJson(clauses);
+    }
+
+    private Map<String, Object> clauseOf(String key, Object value) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(key, value);
+        return map;
+    }
+
+    private Map<String, Object> clauseOf(String key1, Object value1, String key2, Object value2) {
+        Map<String, Object> map = clauseOf(key1, value1);
+        map.put(key2, value2);
+        return map;
+    }
+
+    private Map<String, String> mapOf(String key1, String value1, String key2, String value2) {
+        Map<String, String> map = new HashMap<>();
+        map.put(key1, value1);
+        map.put(key2, value2);
+        return map;
+    }
+
+
+}


### PR DESCRIPTION
This adds rules-based auto exemptions while continuing to support the account-based auto exemptions.
The field is a JSON array stored as a string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exemption rules defined as JSON clauses, alongside the existing account-based exemptions.
  * Clause-based exemptions can match asset fields (including account identifiers).
  * Added match explanations for why an exemption was applied.

* **Bug Fixes**
  * Improved handling for disabled, expired, null, and non-matching exemption rules, including a “No clauses matched” explanation when applicable.

* **Tests**
  * Expanded test coverage for clause matching, empty-clause behavior, account matching, disabled/expired rules, and match explanation strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->